### PR TITLE
unsure why this was commented out, as the bard seems to lock up somet…

### DIFF
--- a/Macros/e3 Includes/e3_Casting.inc
+++ b/Macros/e3 Includes/e3_Casting.inc
@@ -349,7 +349,7 @@ Sub e3_Cast(int targetID, ArrayName, int ArrayIndex)
 	}
 	/if (${Following} && !${Assisting}) /call AcquireFollow
   /if (${Me.Class.ShortName.Equal[BRD]}) /varset resumeTwistDelay 5
-  |/if (${returnTwist})	/call unpauseTwist
+  /if (${returnTwist})	/call unpauseTwist
 	/if (${Debug} || ${Debug_Casting})  /echo |- e3_Cast -| castReturn= ${Cast.Result} ${castReturn}
 |/varset Debug_Casting FALSE
 /return


### PR DESCRIPTION
Rekka: Bard would often lock up after doing the epic click, when i reviewed the debug statements, e3 was running fine but no twisting was happening. I simply restarted the twist and everything was fine. Found a commented if statement at the end of e3_casting that restarted paused twists. uncommented it and everything has since been running fine. This isn't a 100% fix, as I haven't dug too deep but wanted to get it in.