### PR TITLE
Rekka: Been reported that casting while zoning with /clickit can case…

### DIFF
--- a/Macros/e3 Includes/e3_Basics.inc
+++ b/Macros/e3 Includes/e3_Basics.inc
@@ -301,6 +301,13 @@ SUB EVENT_clickIt(line, ChatSender, eventParams)
     :retryClickDoor
     /delay ${clickDelay}
     /squelch /doortarget id ${closestDoorID}
+    
+    |casting while zoning has been reported to cause a problem
+    | If casting, dismount if mounted and call /stopcast
+    /if (${Cast.Status.Find[C]}) {
+      /if (${NetBots[${Me.Name}].Mounted}) /dismount
+      /stopcast
+    }
     /squelch /click left door
     /if (${MyZone}==${Zone.ID} && ${Math.Distance[${startingLoc}]} < 10) {
       /if (${clickTimer}) {

--- a/Macros/e3 Includes/e3_Basics.inc
+++ b/Macros/e3 Includes/e3_Basics.inc
@@ -304,7 +304,7 @@ SUB EVENT_clickIt(line, ChatSender, eventParams)
     
     |casting while zoning has been reported to cause a problem
     | If casting, dismount if mounted and call /stopcast
-    /if (${Cast.Status.Find[C]}) {
+    /if (${Cast.Status.Find[C]} || ${Me.Casting.ID}) {
       /if (${NetBots[${Me.Name}].Mounted}) /dismount
       /stopcast
     }


### PR DESCRIPTION
Rekka: Been reported that casting while zoning with /clickit can case a crash depending on your MQ2 version. Update checks if casting, and if so, dismounts if mounted and then calls /stopcast before clicking. Note I was not able to reproduce on the 2019-09-24 version of MQ2 tho.
