### PR TITLE
Rekka: Little change but a lot of work. A timer on nukes was created …

### DIFF
--- a/Macros/e3 Includes/e3_Assists.inc
+++ b/Macros/e3 Includes/e3_Assists.inc
@@ -387,20 +387,27 @@ SUB check_AutoAssist
 |- Casts direct damage spells on a specified target.	  -|
 |--------------------------------------------------------|
 SUB check_Nukes
+
 /if (${Debug} || ${Debug_Assists}) /echo |- check_Nukes ==>
 	/if (${Defined[Nukes2D]} && ${Assisting} && ${use_Nukes}) {
 	  /declare castIndex int local
 	  /declare s int local
     /declare m int local
     /declare assistToT int local
+    /declare typeOfCast string local 
     /declare HaveGiftOfManaBuff bool False local
     /if (${Bool[${Me.Song[Gift of Mana].ID}]} || ${Bool[${Me.Song[Celestial Gift].ID}]} || ${Bool[${Me.Song[Celestial Boon].ID}]}) {
         /varset HaveGiftOfManaBuff True
     }
 
    /for s 1 to ${Nukes2D.Size[1]}
+    
+    /varset typeOfCast  
+    
     /varset castIndex ${s}
     /if (${Debug} || ${Debug_Assists}) /echo ${s} ${castIndex} ${Nukes2D[${castIndex},${iCastName}]}
+
+    
 
     |allows use of druid/mage DS, etc, in nukes based on spellset. casts on assistTargets target
     /if (${Nukes2D[${castIndex},${iSpellType}].Find[Beneficial]}) {
@@ -419,10 +426,20 @@ SUB check_Nukes
         }
       }
     } else {
+
+      |When an item delay is applied to an entry, check to see if the delay is still active
+      |Check lower comment after the spell is cast for more information.
+      /if (${Defined[nukeSpellRecast_${Nukes2D[${castIndex},${iSpellID}]}]}) {
+        /if (${nukeSpellRecast_${Nukes2D[${castIndex},${iSpellID}]}}) {
+          |/bc check_nuke: skipping nukes as its timer isn't met yet:${Nukes2D[${castIndex},${iCastName}]} time left:${nukeSpellRecast_${Nukes2D[${castIndex},${iSpellID}]}}
+          /goto :skipCast
+        }
+      }
       | skip casting if a delay is defined and active
       /if (${Defined[castDelay${Nukes2D[${castIndex},${iCastID}]}]}) {
         /if (${castDelay${Nukes2D[${castIndex},${iCastID}]}}) {
-          /if (${Debug} || ${Debug_Assists}) /echo skipping nukes, /delay from previous cast
+          /if (${Debug} || ${Debug_Assists}) 
+          /echo skipping nukes, /delay from previous cast
           /return
         }
       }
@@ -439,7 +456,7 @@ SUB check_Nukes
       }
       | if /rotate is defined, and the current array index was the last successful cast, skip to next index
     /if (${Nukes2D[${castIndex},${iCastName}].Equal[${lastSuccessfulCast}]} && ${Nukes2D[${castIndex},${iRotate}]} && ${Nukes2D.Size[1]} > 1) {
-      /if (${Debug} || ${Debug_Assists}) /echo skipping cast of ${Nukes2D[${castIndex},${iCastName}]} /rotate is defined
+      /if (${Debug} || ${Debug_Assists}) /echo Possibly skipping cast of ${Nukes2D[${castIndex},${iCastName}]} /rotate is defined
       |need to check if any of our other spells can cast, if not, we can ignore this rotate
       /declare otherSpellsReady bool local
       /varset otherSpellsReady FALSE
@@ -449,29 +466,40 @@ SUB check_Nukes
       /for i 1 to ${Nukes2D.Size[1]}
         |if not the currently casting spell, lets check if they are ready to cast.          
         /if (!${Nukes2D[${i},${iCastName}].Equal[${currentCastName}]}) {
+          
           /call check_Ready "Nukes2D" ${i}
+          |When an item delay is applied to an entry, check to see if the delay is still active
+          |Check lower comment after the spell is cast for more information.
+          /if (${Defined[nukeSpellRecast_${Nukes2D[${i},${iSpellID}]}]}) {
+            /if (${nukeSpellRecast_${Nukes2D[${i},${iSpellID}]}}) {
+              /varset c_Ready FALSE
+            }
+          }
           /if (${c_Ready} && ${Nukes2D[${i},${iIfs}]}) {
-            /if (${Bool[${Nukes2D[${castIndex},${iGiftOfMana}]}]}) {
+            /if (${Bool[${Nukes2D[${i},${iGiftOfMana}]}]}) {
               |its specified to use gift of mana, well do we have it?
               /if (${HaveGiftOfManaBuff}) {
                 /varset otherSpellsReady TRUE
-                /if (${Debug} || ${Debug_Assists}) /echo other spells ready allowing the skip
+                /if (${Debug} || ${Debug_Assists}) /echo Another spell is defined as ready:${Nukes2D[${i},${iCastName}]}
                 /break
               }
             } else {
               /varset otherSpellsReady TRUE
-              /if (${Debug} || ${Debug_Assists}) /echo other spells ready allowing the skip
+              /if (${Debug} || ${Debug_Assists}) /echo Another spell is defined as ready:${Nukes2D[${i},${iCastName}]}
               /break
             }
           }
         }
       /next i
+   
+    
       |if others spells are ready to cast, its ok to skip this.
         /if (${otherSpellsReady}) {
-            /if (${Debug} || ${Debug_Assists}) /echo calling skipcast
+            |/if (${Debug} || ${Debug_Assists}) /echo another spell is ready to cast
+           
           /goto :skipCast
         } else {
-          /if (${Debug} || ${Debug_Assists}) /echo no other spell ready, allowing the current rotate spell to cast.
+          |/if (${Debug} || ${Debug_Assists}) /echo no other spell ready, allowing the current rotate spell to cast.
         }  
       }
 
@@ -480,11 +508,12 @@ SUB check_Nukes
         /if (${Debug} || ${Debug_Assists}) /echo have gift of mana, selecting GOM spell flag
         /for m 1 to ${Nukes2D.Size[1]}
           /if (${Nukes2D[${m},${iGiftOfMana}]}) {
-          
+        
             /call check_Ready "Nukes2D" ${m}
             /if (${c_Ready}) {
               /if (${Debug} || ${Debug_Assists}) /echo found a ready spell for GOM
               /varset castIndex ${m}
+              |/bc CheckNukes_GOMBUFF: resetting  lastSuccessfulCast 
               /varset lastSuccessfulCast 0
               /break
             } 
@@ -495,7 +524,6 @@ SUB check_Nukes
       /if (!${HaveGiftOfManaBuff} && ${Bool[${Nukes2D[${castIndex},${iGiftOfMana}]}]} ) {
           | we do not have gift of mana, make sure our current index is not a GOM spell, if so skip it
           /if (${Debug} || ${Debug_Assists}) /echo skipping gift of mana spell ${Nukes2D[${castIndex},${iCastName}]}
-          /varset lastSuccessfulCast 0
           /goto :skipcast
       }
 
@@ -546,9 +574,21 @@ SUB check_Nukes
                /varset Nukes2D[${castIndex},${iSubToRun}] check_HealCasting_DuringDetrimental
            
             }
+            /varset typeOfCast ${Nukes2D[${castIndex},${iCastType}]}
             /call e3_Cast ${AssistTarget} "Nukes2D" "${castIndex}"
           }
         }
+      }
+      
+
+      /if (${Select[${castReturn},CAST_SUCCESS]} && ${typeOfCast.Equal[Item]}) {
+          |when an item is click/cast, the server sends over the cooldown of said item
+          |so for a breif time between clicking there is an 'unkown' state where the items
+          |cooldown is still 0, even tho it isn't valid. Noticed this when using molten orbs.
+          |Adding a small delay to any item that is cast to prevent it from being a valid target
+          |on the next event cycle as event cycles in e3 are far faster than the server can send us
+          |the cooldown information
+          /call CreateTimer nukeSpellRecast_${Nukes2D[${castIndex},${iSpellID}]} "1s"
       }
       |if the nuke was succesful, see if there is a delay defined and create a timer which locks out all nukes for the duration
       /if (${Bool[${Nukes2D[${castIndex},${iDelay}]}]} && ${Select[${castReturn},CAST_SUCCESS]}) {

--- a/Macros/e3 Includes/e3_Assists.inc
+++ b/Macros/e3 Includes/e3_Assists.inc
@@ -438,8 +438,7 @@ SUB check_Nukes
       | skip casting if a delay is defined and active
       /if (${Defined[castDelay${Nukes2D[${castIndex},${iCastID}]}]}) {
         /if (${castDelay${Nukes2D[${castIndex},${iCastID}]}}) {
-          /if (${Debug} || ${Debug_Assists}) 
-          /echo skipping nukes, /delay from previous cast
+          /if (${Debug} || ${Debug_Assists}) /echo skipping nukes, /delay from previous cast
           /return
         }
       }
@@ -495,11 +494,11 @@ SUB check_Nukes
     
       |if others spells are ready to cast, its ok to skip this.
         /if (${otherSpellsReady}) {
-            |/if (${Debug} || ${Debug_Assists}) /echo another spell is ready to cast
+          /if (${Debug} || ${Debug_Assists}) /echo another spell is ready to cast
            
           /goto :skipCast
         } else {
-          |/if (${Debug} || ${Debug_Assists}) /echo no other spell ready, allowing the current rotate spell to cast.
+          /if (${Debug} || ${Debug_Assists}) /echo no other spell ready, allowing the current rotate spell to cast.
         }  
       }
 
@@ -513,7 +512,7 @@ SUB check_Nukes
             /if (${c_Ready}) {
               /if (${Debug} || ${Debug_Assists}) /echo found a ready spell for GOM
               /varset castIndex ${m}
-              |/bc CheckNukes_GOMBUFF: resetting  lastSuccessfulCast 
+              /bc CheckNukes_GOMBUFF: resetting  lastSuccessfulCast 
               /varset lastSuccessfulCast 0
               /break
             } 

--- a/Macros/e3 Includes/e3_Casting.inc
+++ b/Macros/e3 Includes/e3_Casting.inc
@@ -139,7 +139,7 @@ Sub e3_Cast(int targetID, ArrayName, int ArrayIndex, bool StopEchos)
 |  Casting
 :cast_spell
   |/if (${Me.Name.Equal[Lube]}) /gu Casting ${pendingCast} ${pendingCastID} ${Spawn[id ${targetID}].Name} ${targetID}
-	/if (!${StopEchos}) /echo Casting ${pendingCast} ${pendingCastID} ${Spawn[id ${targetID}].Name} ${targetID}
+	/if (!${StopEchos}) /echo Casting ${pendingCast} ${pendingCastID} ${Spawn[id ${targetID}].Name} ${targetID} in ${e3CastTime}
 	|~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	|Use Disc
 	/if (${${ArrayName}[${ArrayIndex},${iCastType}].Equal[Disc]}) {
@@ -153,7 +153,7 @@ Sub e3_Cast(int targetID, ArrayName, int ArrayIndex, bool StopEchos)
 				/squelch /target id ${targetID}
 				/delay 5 ${Target.ID} == ${targetID}
 			}
-      /varset ActionTaken TRUE
+			/varset ActionTaken TRUE
 			/disc ${pendingCast}
 		}
 	|-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -197,12 +197,19 @@ Sub e3_Cast(int targetID, ArrayName, int ArrayIndex, bool StopEchos)
 		}
     |/echo AT pendingCastID ${pendingCastID} pendingType ${pendingType}" "-targetid|${targetID}"
 	/varset ActionTaken TRUE
+	
+
     /if (${${ArrayName}[${ArrayIndex},${iTargetType}].Equal[Self]}) {
 		/if (${Bool[${FindItem[=${pendingCast}]}]}) {
+
 			/useitem "${pendingCast}"
-			/delay 3
 			|set to a default good value unless overwritten for a reason
 			/varset castReturn CAST_SUCCESS
+			|Note when using /useitem, if the next 'cast' is a spell you need a 0.3 sec delay similar to bard songs.
+			|Possible optimizations to pass in to use the delay or not, but be warned, not using the delay
+			|and the spell is the next can get you to a point where your spell gems lock up and need to use an AA to fix.
+			/delay 3
+			
 
 		} else {
 			/casting "${pendingCastID}|${pendingType}"		
@@ -222,9 +229,14 @@ Sub e3_Cast(int targetID, ArrayName, int ArrayIndex, bool StopEchos)
 			/next i_target
 			|/echo casting item "${pendingCast}" on ${targetID}
 			/useitem "${pendingCast}"
-			/delay 3
 			|set to a default good value unless overwritten for a reason
 			/varset castReturn CAST_SUCCESS
+			|Note when using /useitem, if the next 'cast' is a spell you need a 0.3 sec delay similar to bard songs.
+			|Possible optimizations to pass in to use the delay or not, but be warned, not using the delay
+			|and the spell is the next can get you to a point where your spell gems lock up and need to use an AA to fix.
+			/delay 3
+			|set to a default good value unless overwritten for a reason
+			
 		} else {
 			/casting "${pendingCastID}|${pendingType}" "-targetid|${targetID}"
 		}
@@ -352,6 +364,7 @@ Sub e3_Cast(int targetID, ArrayName, int ArrayIndex, bool StopEchos)
   /if (${Me.Class.ShortName.Equal[BRD]}) /varset resumeTwistDelay 5
   /if (${returnTwist})	/call unpauseTwist
 	/if (${Debug} || ${Debug_Casting})  /echo |- e3_Cast -| castReturn= ${Cast.Result} ${castReturn}
+
 |/varset Debug_Casting FALSE
 /return
 

--- a/Macros/e3 Includes/e3_Utilities.inc
+++ b/Macros/e3 Includes/e3_Utilities.inc
@@ -290,7 +290,8 @@ SUB BuildSpellArray(ArrayName, NewArrayName)
   	/if (!${Defined[iIfs]})		/declare iIfs int outer 42
   
 	/declare i int local
-	/declare printAll bool local FALSE
+	/declare printAll bool local False
+	/declare printMin bool local False
 	|first loop through array to ensure i can identify all listed spells
 	/declare tmp_castname string local
 	/declare remove_index int local
@@ -330,7 +331,7 @@ SUB BuildSpellArray(ArrayName, NewArrayName)
 	/for i 1 to ${${ArrayName}.Size}
     | get SpellName
 		/varset ${NewArrayName}[${i},${iCastName}] ${${ArrayName}[${i}].Arg[1,/]}
-		/if (${printAll}) /echo CastName ${${NewArrayName}[${i},${iCastName}]}
+		/if (${printAll} || ${printMin}) /echo CastName ${${NewArrayName}[${i},${iCastName}]}
 
 		| get CastType
 		/if (${Bool[${Me.AltAbility[${${NewArrayName}[${i},${iCastName}]}].Spell}]}) {
@@ -344,7 +345,7 @@ SUB BuildSpellArray(ArrayName, NewArrayName)
 		} else {
       /varset ${NewArrayName}[${i},${iCastType}] Item
 		}
-    /if (${printAll}) /echo CastType ${${NewArrayName}[${i},${iCastType}]}
+    /if (${printAll}  || ${printMin}) /echo CastType ${${NewArrayName}[${i},${iCastType}]}
 		
 		| get TargetType
 		/if (${${NewArrayName}[${i},${iCastType}].Equal[Item]}) {
@@ -408,7 +409,7 @@ SUB BuildSpellArray(ArrayName, NewArrayName)
       /varset	${NewArrayName}[${i},${iDuration}] ${Spell[${${NewArrayName}[${i},${iCastName}]}].Duration}
     }
 
-		/if (${printAll}) /echo SpellDuration ${${NewArrayName}[${i},${iDuration}]}
+		/if (${printAll}  || ${printMin}) /echo SpellDuration ${${NewArrayName}[${i},${iDuration}]}
 		
 		| get RecastTime
 		/if (${${NewArrayName}[${i},${iCastType}].Equal[Item]}) {
@@ -418,7 +419,7 @@ SUB BuildSpellArray(ArrayName, NewArrayName)
 		} else /if (${${NewArrayName}[${i},${iCastType}].Equal[Spell]}) {
 			/varset	${NewArrayName}[${i},${iRecastTime}] ${Spell[${${NewArrayName}[${i},${iCastName}]}].RecastTime}			
 		} 
-		/if (${printAll}) /echo RecastTime ${${NewArrayName}[${i},${iRecastTime}]}
+		/if (${printAll}|| ${printMin}) /echo RecastTime ${${NewArrayName}[${i},${iRecastTime}]}
 
 		| get RecoveryTime
 		/if (${${NewArrayName}[${i},${iCastType}].Equal[Item]}) {
@@ -438,7 +439,7 @@ SUB BuildSpellArray(ArrayName, NewArrayName)
 		} else /if (${${NewArrayName}[${i},${iCastType}].Equal[Spell]}) {
 			/varset	${NewArrayName}[${i},${iMyCastTime}] ${Spell[${${NewArrayName}[${i},${iCastName}]}].MyCastTime}			
 		} 
-		/if (${printAll}) /echo ${NewArrayName} ${i}  MyCastTime ${${NewArrayName}[${i},${iMyCastTime}]}
+		/if (${printAll} || ${printMin}) /echo ${NewArrayName} ${i}  MyCastTime ${${NewArrayName}[${i},${iMyCastTime}]}
 		
 		| get MyRange
 		/if (${${NewArrayName}[${i},${iCastType}].Equal[Item]}) {
@@ -581,7 +582,7 @@ SUB BuildSpellArray(ArrayName, NewArrayName)
 			/call argueString Delay| "${${ArrayName}[${i}]}"
 			/varset ${NewArrayName}[${i},${iDelay}] ${c_argueString}
 		}
-		/if (${printAll}) /echo Delay ${${NewArrayName}[${i},${iDelay}]}		
+		/if (${printAll} || ${printMin}) /echo Delay ${${NewArrayName}[${i},${iDelay}]}		
 
 		| get CastID
 		/if (${${NewArrayName}[${i},${iCastType}].Equal[Item]}) {


### PR DESCRIPTION
…to prevent an item from being 'attempted' to be cast mutiple times even if it was on cooldown. E3 would cast the item, then loop back around and it would see the item as a valid cast again as "cooldown" would not be set yet. Now a 1 second timer is created for any nuke to give time for the client to get the updated value and start the items cooldown. This probably should be done in other areas but at the time I was testing Molten Orb from the mage.

Also note, Item->Spell will always required the 0.3 sec delay, Item->Item you can ignore it, and I am unsure with Item->AA. If you do not do this, you will eventually lock up and require an AA cast to 'fix' the issue.  There may be a future update where we allow e3 to 'told' to ignore the item delay, if the parent code 'knows' that the next the next thing will be an Item. Tho honestly, losing 0.3 sec on item casts seems like a minor issue.

Note that i forgot to add in the comment. Fix bug in /GoM flag.