### PR TITLE
Feature/cast now

### DIFF
--- a/Macros/e3 Includes/e3_Casting.inc
+++ b/Macros/e3 Includes/e3_Casting.inc
@@ -38,6 +38,9 @@ Sub e3_Cast(int targetID, ArrayName, int ArrayIndex, bool StopEchos)
 	/declare pendingType	string local
   /declare oldItem			string local
 	/declare i						int local
+	|this needs to be set to true every run, as its checked for interrupt method calls. Technically they set it to true every time they run, but best to 
+	|be sure this is reset.
+	/varset c_SubToRun TRUE
   |/varset Debug_Casting TRUE
 |~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 | Checks to abort casting due to previous failures
@@ -249,6 +252,10 @@ Sub e3_Cast(int targetID, ArrayName, int ArrayIndex, bool StopEchos)
 |- check for reasons to cancel casting
 		/if (${Cast.Status.Find[C]}) {
 		  |dont allow item swap/must equip interrupts to avoid crashes
+
+
+			
+
 		  /if (${oldItem.Length}) {
 		    /delay 1
 		    /goto :cast_still_pending
@@ -272,8 +279,19 @@ Sub e3_Cast(int targetID, ArrayName, int ArrayIndex, bool StopEchos)
 				} else {
 				  /delay 1
 				}
-				|this will make tank and important heals ignore everything but subToRun
-       			 /if (${Select[${ArrayName},tankHeals2D,importantHeals2D]}) /goto :cast_still_pending
+				|this will make tank/important heals ignore everything but subToRun
+       			 /if (${Select[${ArrayName},tankHeals2D,importantHeals2D,xtargetHeals2D]}) /goto :cast_still_pending
+
+				/doevents nowCast
+				/doevents nowCastNoTarget
+				|check to see if now Cast has decided to interrupt the casting.
+				/if (!${g_CastNowSpellCasting} && (!${c_SubToRun} && ${Me.Casting.ID})) {
+							/if (${Debug} || ${Debug_Casting}) /echo nowCast called interrupt ${${ArrayName}[${ArrayIndex},${iSubToRun}]}
+							/call interrupt
+							/delay 1s
+							/goto :interrupted
+				}
+
 				|- Other reasons to cancel
 				/if (!${Assisting} && ${Following}) {
 				/if (${SpawnCount[=${FollowTarget}]} && ${Spawn[=${FollowTarget}].Distance} < ${LeashLength}) {

--- a/Macros/e3 Includes/e3_Casting.inc
+++ b/Macros/e3 Includes/e3_Casting.inc
@@ -283,7 +283,6 @@ Sub e3_Cast(int targetID, ArrayName, int ArrayIndex, bool StopEchos)
        			 /if (${Select[${ArrayName},tankHeals2D,importantHeals2D,xtargetHeals2D]}) /goto :cast_still_pending
 
 				/doevents nowCast
-				/doevents nowCastNoTarget
 				|check to see if now Cast has decided to interrupt the casting.
 				/if (!${g_CastNowSpellCasting} && (!${c_SubToRun} && ${Me.Casting.ID})) {
 							/if (${Debug} || ${Debug_Casting}) /echo nowCast called interrupt ${${ArrayName}[${ArrayIndex},${iSubToRun}]}

--- a/Macros/e3 Includes/e3_NowCast.inc
+++ b/Macros/e3 Includes/e3_NowCast.inc
@@ -31,7 +31,7 @@ Sub NowCast_CircularQueue_Insert(InsertValue)
     /varset nowSpellArrayQueueIndexBack ${Math.Calc[(${nowSpellArrayQueueIndexBack} + 1) % ${nowSpellArrayQueueMax}]}
     |Array indexes starting at 1 is stupid and the person should be flogged with a wet fish
     /declare arrayIndex int local ${Math.Calc[${nowSpellArrayQueueIndexBack}+1]}
-    |/if (${DebugNowCast}) /echo Addding with array index of ${arrayIndex} with value ${InsertValue}
+    |/echo Addding with array index of ${arrayIndex} with value ${InsertValue}
     /varset nowSpellArrayQueue[${arrayIndex}] ${InsertValue}
     /varcalc nowSpellArrayQueueCount ${nowSpellArrayQueueCount}+1
 
@@ -53,7 +53,7 @@ SUB castNowSpells
     /declare spellArgs string local 
     /declare spellName string local
     /declare spellTargetID int local
-
+    
     /while (${nowSpellArrayQueueCount}>0) {
         |get the value out of the queue
         /call NowCast_CircularQueue_Pop
@@ -72,7 +72,7 @@ SUB castNowSpells
         /if (${Me.SpellReady[${spellName}]} || ${Me.AltAbilityReady[${spellName}]} || ${Me.ItemReady[${spellName}]}) {
             /call castNowSpell "${spellName}" ${spellTargetID}
             /if (!(${ActionTaken} && ${castReturn.Equal[CAST_SUCCESS]})) {
-                /echo NowCast: Failed to cast ${spellName} due to ${castReturn}
+                /echo <NowCast>: Failed to cast ${spellName} due to ${castReturn}
             } else /if (${nowSpellArrayQueueCount}>0 ) {
                 |give times global cooldown if this is not an item
                 /if (!${Bool[${FindItemCount[=${spellName}]}]}) {
@@ -81,7 +81,7 @@ SUB castNowSpells
                 
             }
         } else {
-            /echo NowCast: Failed to cast ${spellName}, Spell/Ability/Item not ready or not found
+            /bc <NowCast>: Failed to cast ${spellName}, Spell/Ability/Item not ready or not found
         } 
     }
 /RETURN
@@ -101,32 +101,29 @@ SUB castNowSpell(spellName, targetID)
 	}
 /RETURN
 | Add a spell to the queue with no targetid
-#event nowCastNoTarget "<#1#> #2# nowCast #3#"
-#event nowCastNoTarget "[#1#(msg)]#2# nowCast #3#"
-SUB event_nowCastNoTarget(line, ChatSender, Caster, spellName)
-	/if (${Bool[${Caster}]} &&!${Me.Name.Equal[${Caster}]}) /return
+#event nowCast "<#1#> #2# nowCast #3#"
+#event nowCast "[#1#(msg)]#2# nowCast #3#"
+SUB event_nowCast(line, ChatSender, Caster, spellName)
+    /if (${Bool[${Caster}]} &&!${Me.Name.Equal[${Caster}]}) /return
+
+    /declare targetID int local ${Me.ID}
+    /declare spellIndexStart int local 0
+    /declare targetIDIndex int local 0
+
+    /if (${Bool[${spellName.Length}]}) {
+        /varset targetIDIndex ${spellName.Find[targetid]}
+        /if (${targetIDIndex}>0) {
+            /varset targetID ${spellName.Token[2,=]}
+            /varset spellName ${spellName.Left[${Math.Calc[${targetIDIndex}-2]}]}       
+        }
+    }
     /if (${nowSpellArrayQueueCount}==${nowSpellArrayQueueMax}) {
         /echo CastNow Queue is maxed, dropping ${spellName},${targetID}
         /return
     }
-    /call NowCast_CircularQueue_Insert "${spellName},${Me.ID}"
+    /call NowCast_CircularQueue_Insert "${spellName},${targetID}"
 	|c_SubToRun is used internally by e3_Cast, we are flaggint that if something was casting, we would like to interrupt 
     |once we leave this  e3_Casting should check the flag and then call an interrupt
     /if (!${g_CastNowSpellCasting}) /varset c_SubToRun FALSE
 /RETURN
-| Adds spells to the queue with a targetid
-#event nowCast "<#1#> #2# nowCast #3# targetid=#4#"
-#event nowCast "[#1#(msg)]#2# nowCast #3# targetid=#4#"
-SUB event_nowCast(line, ChatSender, Caster, spellName, targetID)
-    /if (${Bool[${Caster}]} &&!${Me.Name.Equal[${Caster}]}) /return
-    /if (${nowSpellArrayQueueCount}==${nowSpellArrayQueueMax}) {
-        /echo CastNow Queue is maxed, dropping ${spellName},${targetID}
-        /return
-    }
-    |/echo Appending Now casting with target ${spellName} on ${Spawn[${targetID}].CleanName}
-    /call NowCast_CircularQueue_Insert "${spellName},${targetID}"
 
-    |c_SubToRun is used internally by e3_Cast, we are flaggint that if something was casting, we would like to interrupt 
-    |once we leave this  e3_Casting should check the flag and then call an interrupt
-     /if (!${g_CastNowSpellCasting}) /varset c_SubToRun FALSE
-/RETURN

--- a/Macros/e3 Includes/e3_NowCast.inc
+++ b/Macros/e3 Includes/e3_NowCast.inc
@@ -2,7 +2,7 @@
 | Now Cast
 |
 | Author: Rekka
-| This is for when you need something cast immediatly. Unless its a Tank heal,
+| This is for when you need something cast immediately. Unless its a Tank heal,
 | Important heal, or XTarget Heal in process. This will stop whatever is being cast.
 | by issuing an interrupt, which will kick out to the main event loop and then
 | the very next method called will be castNowSpells. 
@@ -13,10 +13,10 @@
 |--------------------------------------------------------------------------------|
 Sub NowCastDefinedValues
     |Create a circular queue with insert and pop methods
-    /declare nowSpellArrayQueue[5] string outer
+    /declare nowSpellArrayQueue[10] string outer
     /declare nowSpellArrayQueueIndexFront int outer 0
     /declare nowSpellArrayQueueIndexBack int outer -1
-    /declare nowSpellArrayQueueMax int outer 5
+    /declare nowSpellArrayQueueMax int outer 10
     /declare nowSpellArrayQueueCount int outer 0
  	/declare DebugNowCast bool outer FALSE
     |global variable to determine if this is a now cast spell while casting
@@ -73,6 +73,12 @@ SUB castNowSpells
             /call castNowSpell "${spellName}" ${spellTargetID}
             /if (!(${ActionTaken} && ${castReturn.Equal[CAST_SUCCESS]})) {
                 /echo NowCast: Failed to cast ${spellName} due to ${castReturn}
+            } else /if (${nowSpellArrayQueueCount}>0 ) {
+                |give times global cooldown if this is not an item
+                /if (!${Bool[${FindItemCount[=${spellName}]}]}) {
+		           /delay 15
+            	}	
+                
             }
         } else {
             /echo NowCast: Failed to cast ${spellName}, Spell/Ability/Item not ready or not found

--- a/Macros/e3 Includes/e3_NowCast.inc
+++ b/Macros/e3 Includes/e3_NowCast.inc
@@ -1,0 +1,126 @@
+|--------------------------------------------------------------------------------|
+| Now Cast
+|
+| Author: Rekka
+| This is for when you need something cast immediatly. Unless its a Tank heal,
+| Important heal, or XTarget Heal in process. This will stop whatever is being cast.
+| by issuing an interrupt, which will kick out to the main event loop and then
+| the very next method called will be castNowSpells. 
+|--------------------------------------------------------------------------------|
+
+|--------------------------------------------------------------------------------|
+| Declare variables used in the macro
+|--------------------------------------------------------------------------------|
+Sub NowCastDefinedValues
+    |Create a circular queue with insert and pop methods
+    /declare nowSpellArrayQueue[5] string outer
+    /declare nowSpellArrayQueueIndexFront int outer 0
+    /declare nowSpellArrayQueueIndexBack int outer -1
+    /declare nowSpellArrayQueueMax int outer 5
+    /declare nowSpellArrayQueueCount int outer 0
+ 	/declare DebugNowCast bool outer FALSE
+    |global variable to determine if this is a now cast spell while casting
+    /declare g_CastNowSpellCasting bool outer FALSE
+/RETURN
+Sub NowCast_CircularQueue_Insert(InsertValue)
+
+    /if (${nowSpellArrayQueueCount}==${nowSpellArrayQueueMax}) {
+        /echo NowCast Queue Overflow, throwing away ${InsertValue}
+        /return
+    }
+    /varset nowSpellArrayQueueIndexBack ${Math.Calc[(${nowSpellArrayQueueIndexBack} + 1) % ${nowSpellArrayQueueMax}]}
+    |Array indexes starting at 1 is stupid and the person should be flogged with a wet fish
+    /declare arrayIndex int local ${Math.Calc[${nowSpellArrayQueueIndexBack}+1]}
+    |/if (${DebugNowCast}) /echo Addding with array index of ${arrayIndex} with value ${InsertValue}
+    /varset nowSpellArrayQueue[${arrayIndex}] ${InsertValue}
+    /varcalc nowSpellArrayQueueCount ${nowSpellArrayQueueCount}+1
+
+/return
+Sub NowCast_CircularQueue_Pop
+    /if (${nowSpellArrayQueueCount}==0) {
+        /echo NowCast Queue Empty Already
+        /return
+    }
+    /declare returnValue string local ${nowSpellArrayQueue[${Math.Calc[${nowSpellArrayQueueIndexFront}+1]}]}
+    /varset nowSpellArrayQueueIndexFront ${Math.Calc[(${nowSpellArrayQueueIndexFront} + 1) % ${nowSpellArrayQueueMax}]}
+    /varcalc nowSpellArrayQueueCount ${nowSpellArrayQueueCount}-1
+
+/return ${returnValue}
+| Casts the spell at the front of the queue
+SUB castNowSpells
+    |a check to make double sure we notify the rest of the program we are not casting yet.
+    /varset g_CastNowSpellCasting False
+    /declare spellArgs string local 
+    /declare spellName string local
+    /declare spellTargetID int local
+
+    /while (${nowSpellArrayQueueCount}>0) {
+        |get the value out of the queue
+        /call NowCast_CircularQueue_Pop
+        /varset spellArgs ${Macro.Return}
+        
+        /varset spellName ${spellArgs.Arg[1,,]}
+        /varset spellTargetID ${spellArgs.Arg[2,,]}
+
+        /if (${DebugNowCast}) /echo spellName:${spellName}
+        /if (${spellTargetID}==0) {
+            /echo nowCast targetID is 0, Target was not supplied correctly
+            /return
+        }
+        /if (${DebugNowCast}) /echo nowCast targetID: ${spellTargetID} 	
+        | Check if SpellReady/AltAbilityReady
+        /if (${Me.SpellReady[${spellName}]} || ${Me.AltAbilityReady[${spellName}]} || ${Me.ItemReady[${spellName}]}) {
+            /call castNowSpell "${spellName}" ${spellTargetID}
+            /if (!(${ActionTaken} && ${castReturn.Equal[CAST_SUCCESS]})) {
+                /echo NowCast: Failed to cast ${spellName} due to ${castReturn}
+            }
+        } else {
+            /echo NowCast: Failed to cast ${spellName}, Spell/Ability/Item not ready or not found
+        } 
+    }
+/RETURN
+| Calls e3_Cast for the given spell at the given target
+SUB castNowSpell(spellName, targetID)
+
+	/declare whatToCast string local
+	/if (${Bool[${Me.Book[${spellName}]}]} || ${Bool[${Me.AltAbility[${spellName}]}]}) {
+		/varset whatToCast ${spellName}
+	} else /if (${Bool[${FindItemCount[=${spellName}]}]}) {
+		/varset whatToCast ${FindItem[=${spellName}]}
+	}	
+	/if (${Bool[${whatToCast}]}) {
+        /varset g_CastNowSpellCasting TRUE
+        /call castSimpleSpell "${whatToCast}" ${targetID}
+        /varset g_CastNowSpellCasting False
+	}
+/RETURN
+| Add a spell to the queue with no targetid
+#event nowCastNoTarget "<#1#> #2# nowCast #3#"
+#event nowCastNoTarget "[#1#(msg)]#2# nowCast #3#"
+SUB event_nowCastNoTarget(line, ChatSender, Caster, spellName)
+	/if (${Bool[${Caster}]} &&!${Me.Name.Equal[${Caster}]}) /return
+    /if (${nowSpellArrayQueueCount}==${nowSpellArrayQueueMax}) {
+        /echo CastNow Queue is maxed, dropping ${spellName},${targetID}
+        /return
+    }
+    /call NowCast_CircularQueue_Insert "${spellName},${Me.ID}"
+	|c_SubToRun is used internally by e3_Cast, we are flaggint that if something was casting, we would like to interrupt 
+    |once we leave this  e3_Casting should check the flag and then call an interrupt
+    /if (!${g_CastNowSpellCasting}) /varset c_SubToRun FALSE
+/RETURN
+| Adds spells to the queue with a targetid
+#event nowCast "<#1#> #2# nowCast #3# targetid=#4#"
+#event nowCast "[#1#(msg)]#2# nowCast #3# targetid=#4#"
+SUB event_nowCast(line, ChatSender, Caster, spellName, targetID)
+    /if (${Bool[${Caster}]} &&!${Me.Name.Equal[${Caster}]}) /return
+    /if (${nowSpellArrayQueueCount}==${nowSpellArrayQueueMax}) {
+        /echo CastNow Queue is maxed, dropping ${spellName},${targetID}
+        /return
+    }
+    |/echo Appending Now casting with target ${spellName} on ${Spawn[${targetID}].CleanName}
+    /call NowCast_CircularQueue_Insert "${spellName},${targetID}"
+
+    |c_SubToRun is used internally by e3_Cast, we are flaggint that if something was casting, we would like to interrupt 
+    |once we leave this  e3_Casting should check the flag and then call an interrupt
+     /if (!${g_CastNowSpellCasting}) /varset c_SubToRun FALSE
+/RETURN

--- a/Macros/e3 Includes/e3_Setup.inc
+++ b/Macros/e3 Includes/e3_Setup.inc
@@ -23,6 +23,7 @@
 #include e3 Includes\e3_Utilities.inc
 #include e3 Includes\e3_Wait4Rez.inc
 #include e3 Includes\e3_QueueCast.inc
+#include e3 Includes\e3_NowCast.inc
 #include e3 Includes\e3_ClearXTargets.inc
 
 #include e3 Includes\e3_Classes_Bard.inc
@@ -54,6 +55,7 @@ SUB e3_Setup(modeSelect)
 	/declare missingSpellItem string outer
 	/declare numInventorySlots int outer 10
 	/call BuildSpellArrayDefinedValues
+	/call NowCastDefinedValues
 
 	/if (${modeSelect.Equal[Debug]}) /varset Debug TRUE
 	| The file path for e3 Data.ini will still need to be updated in corresponding includes because you must use /noparse to write variables to inis.

--- a/Macros/e3.mac
+++ b/Macros/e3.mac
@@ -47,8 +47,7 @@ SUB Main(modeSelect)
           /call ${mainLoop_Array[${i}]}
           |check to see if anything has been set to try and cast without an interrupt
           /doevents nowCast
-				  /doevents nowCastNoTarget
-          |check to see if we have spell(s) ready in nowCast that may have interrupted the above call
+				  |check to see if we have spell(s) ready in nowCast that may have interrupted the above call
           /call castNowSpells
         } 
       /if (!${ActionTaken}) /next i

--- a/Macros/e3.mac
+++ b/Macros/e3.mac
@@ -42,8 +42,15 @@ SUB Main(modeSelect)
 		/if (!${activeTimer}) {
       |These are functions in the e3_setup/Advanced.ini class sections... ex CLR Function#1=check_DivineArb
 			/for i 1 to ${mainLoop_Array.Size}
-				/if (${Bool[${mainLoop_Array[${i}]}]}) /call ${mainLoop_Array[${i}]}
-			/if (!${ActionTaken}) /next i
+				/if (${Bool[${mainLoop_Array[${i}]}]}) {
+          /call ${mainLoop_Array[${i}]}
+          |check to see if anything has been set to try and cast without an interrupt
+          /doevents nowCast
+				  /doevents nowCastNoTarget
+          |check to see if we have spell(s) ready in nowCast that may have interrupted the above call
+          /call castNowSpells
+        } 
+      /if (!${ActionTaken}) /next i
 
       /if (${Me.CombatState.NotEqual[COMBAT]}) {
         /if ((!${Me.Casting.ID} || ${Me.Class.ShortName.Equal[BRD]}) && !${use_TargetAE}) /call completePendingExchange

--- a/Macros/e3.mac
+++ b/Macros/e3.mac
@@ -26,6 +26,7 @@ SUB Main(modeSelect)
 :MainLoop
 /if (${Debug}) /echo |- MainLoop ==>
 		/varset ActionTaken FALSE
+    
     /call check_Basics
  		/call check_Active
 		/call check_Idle


### PR DESCRIPTION
Rekka: New Feature. 
/bct (character) nowCast (spell) (targetid=#)
/bc (character) nowCast (spell) (targetid=#)

use bct, to prevent broadcast to other toons which causes the event to fire off and then be ignored.

This is the far more aggressive cousin of queueCast. 

This is for when you need something cast immediately. Unless its a Tank heal,
Important heal, or XTarget Heal in process. This will stop whatever is being cast.
by issuing an interrupt, which will kick out to the main event loop and then
the very next method called will be castNowSpells. 