### PR TITLE
Feature/item click issues

### DIFF
--- a/Macros/e3 Includes/e3_Alerts.inc
+++ b/Macros/e3 Includes/e3_Alerts.inc
@@ -112,7 +112,8 @@ Sub event_angmask
     /delay 3s !${Me.Casting.ID}
     :retry
     /varcalc numtries ${numtries}+1
-    /casting "Mirrored Mask" -maxtries|3
+    /call castSimpleSpell "Mirrored Mask" 0
+    |/casting "Mirrored Mask" -maxtries|3
     /delay 1s
     /if (!${Bool[${Me.Song[Reflective Skin]}]} && ${numtries} < 8) /goto :retry
   }

--- a/Macros/e3 Includes/e3_Assists.inc
+++ b/Macros/e3 Includes/e3_Assists.inc
@@ -314,7 +314,7 @@ SUB CombatAbilities
         /if (!${Select[${Me.Inventory[Offhand].Type},Shield]} && !${Me.AltAbility[2 Hand Bash]}) /goto :skipAbility
         |can't do anything if stunned.
         /if (${Me.Stunned}) /goto :skipAbility
-        /if (${Target.Distance} >10) /goto :skipAbility
+        /if (${Target.Distance} >14) /goto :skipAbility
         
       }
       /if (${Me.AbilityReady[${Abilities2D[${i},${iCastName}]}]}) {

--- a/Macros/e3 Includes/e3_Assists.inc
+++ b/Macros/e3 Includes/e3_Assists.inc
@@ -1465,8 +1465,8 @@ SUB useBurns(ArrayName)
       /if (${Debug} || ${Debug_Assists}) /echo useBurns ${ArrayName}: NotReady: ${i} ${${ArrayName}[${i},${iCastName}]}
     }
     :skipCurrent
-    /if (${isHealer}) {
-        |interupt stoning if we have someone to heal
+    /if (${isHealer} && !${${ArrayName}[${i},${iNoInterrupt}]} && !${ArrayName.Equal[EPICBurns2D]}) {
+        |interupt burning if we have someone to heal
         /call check_HealCasting_DuringBurns
         /if (!${c_SubToRun}) {
           	/echo [${Time}]: useBurns: ${ArrayName}: healer needs to heal jumping out of burn.

--- a/Macros/e3 Includes/e3_Assists.inc
+++ b/Macros/e3 Includes/e3_Assists.inc
@@ -635,7 +635,10 @@ SUB check_OffAssistSpells
 |- Enables Debuffing on a Target                    -|
 |----------------------------------------------------|
 SUB check_Debuffs
-  /if (${Defined[Command_Debuffs2D]}) /call Debuffs_OnCommand
+  /if (${Defined[Command_Debuffs2D]}) {
+    /call Debuffs_OnCommand
+  } 
+  
   /if (${Defined[All_Debuffs2D]}) /call Debuffs_OnAll
 	/if (${Assisting} && ${Defined[Assist_Debuffs2D]}) /call cast_longTermSpells "${AssistTarget}" "Assist_Debuffs2D"
 /if (${Debug} || ${Debug_Assists}) /echo <== check_Debuffs -|
@@ -719,6 +722,7 @@ SUB cast_longTermSpells(int spellTarget, string ArrayName)
                /varset ${ArrayName}[${s},${iSubToRun}] check_HealCasting_DuringDetrimental
             }
           /call e3_Cast ${spellTarg} "${ArrayName}" "${s}"
+       
         } else {
           /if (${Debug} || ${Debug_Assists}) /echo ${spellTarg} out of range for ${${ArrayName}[${s},${iMyRange}]} ${${ArrayName}[${s},${iCastName}]}
           /goto :skipCast

--- a/Macros/e3 Includes/e3_Assists.inc
+++ b/Macros/e3 Includes/e3_Assists.inc
@@ -256,7 +256,7 @@ SUB check_AssistStatus
       /if (!${Me.AutoFire}) /autofire on
     }
   }
-  /if ((!${Me.Casting.ID} || ${Me.Class.ShortName.Equal[BRD]}) && (${Me.Combat} || ${Me.CombatState.Equal[Combat]} ||  ${AssistTarget} >0 ) && ${Defined[Abilities2D]}) /call CombatAbilities
+  /if ((!${Me.Casting.ID} || ${Me.Class.ShortName.Equal[BRD]}) && (${Me.Combat} || ${Me.CombatState.Equal[Combat]} ||  ${AssistTarget} >0 ) && ${Target.ID} == ${AssistTarget} && ${Defined[Abilities2D]}) /call CombatAbilities
 /if (${Debug} || ${Debug_Assists}) /echo <== check_AssistStatus -|
 /RETURN
 

--- a/Macros/e3 Includes/e3_Assists.inc
+++ b/Macros/e3 Includes/e3_Assists.inc
@@ -1432,25 +1432,33 @@ SUB useBurns(ArrayName)
 	/declare i int local
 	/for i 1 to ${${ArrayName}.Size[1]}
 
+    /echo useBurns ${ArrayName}: calling check for ${${ArrayName}[${i},${iCastName}]}
     /call check_Ready "${ArrayName}" ${i}
-    |/echo ${i} ${${ArrayName}[${i},${iCastName}]} tgt ${AssistTarget} rng ${${ArrayName}[${i},${iMyRange}]}
-    |/echo ${i} rdy ${c_Ready} dist ${check_Distance[${AssistTarget},${${ArrayName}[${i},${iMyRange}]}]}
     /if (${c_Ready} && ${${ArrayName}[${i},${iIfs}]}) {
+
+       /echo useBurns ${ArrayName}: check for passed ${${ArrayName}[${i},${iCastName}]}
       /if (${check_Distance[${AssistTarget},${${ArrayName}[${i},${iMyRange}]}]}) {
+       
         /if (${Me.ActiveDisc.ID} && ${${ArrayName}[${i},${iCastName}].Equal[Savage Spirit]}) /goto :skipCurrent
         /if (${Me.ActiveDisc.ID} && ${${ArrayName}[${i},${iCastType}].Equal[Disc]} && ${Bool[${${ArrayName}[${i},${iDuration}]}]}) /goto :skipCurrent
-        /call e3_Cast ${AssistTarget} "${ArrayName}" "${i}"
-        |/delay 2
-        |/varset ActionTaken TRUE
-        /call check_Ready "${ArrayName}" ${i}
-        /if (!${c_Ready}) /g ${ArrayName}-${${ArrayName}[${i},${iCastName}]}
+        
+        /echo useBurns ${ArrayName}: Issuing cast for  ${${ArrayName}[${i},${iCastName}]}
+        /call e3_Cast ${AssistTarget} "${ArrayName}" "${i}" 0
+       
+        /if (${Select[${castReturn},CAST_SUCCESS]}) {
+          /g ${ArrayName}-${${ArrayName}[${i},${iCastName}]}
+        } else {
+          /g ${castReturn}: ${ArrayName}-${${ArrayName}[${i},${iCastName}]}
+        }
+       
       }
     } else {
-      /if (${Debug} || ${Debug_Assists}) /echo NotReady: ${i} ${${ArrayName}[${i},${iCastName}]}
+      /echo useBurns ${ArrayName}: NotReady: ${i} ${${ArrayName}[${i},${iCastName}]}
     }
-  :skipCurrent
-  |/delay 1
-  /if (!${ActionTaken}) /next i
+    :skipCurrent
+    |/delay 1
+  /next i
+
 /if (${Debug} || ${Debug_Assists}) /echo <== useBurns -|
 /RETURN
 

--- a/Macros/e3 Includes/e3_Assists.inc
+++ b/Macros/e3 Includes/e3_Assists.inc
@@ -1429,20 +1429,18 @@ SUB event_Burns(line, ChatSender, burnType)
 |--------------------------------------------------------------------------------|
 SUB useBurns(ArrayName)
 /if (${Debug} || ${Debug_Assists}) /echo |- useBurns Array=${ArrayName} ==>
+
 	/declare i int local
+  /declare isHealer bool Local ${Select[${Me.Class.ShortName},CLR,DRU,SHM]}
 	/for i 1 to ${${ArrayName}.Size[1]}
 
-    /echo useBurns ${ArrayName}: calling check for ${${ArrayName}[${i},${iCastName}]}
     /call check_Ready "${ArrayName}" ${i}
     /if (${c_Ready} && ${${ArrayName}[${i},${iIfs}]}) {
 
-       /echo useBurns ${ArrayName}: check for passed ${${ArrayName}[${i},${iCastName}]}
       /if (${check_Distance[${AssistTarget},${${ArrayName}[${i},${iMyRange}]}]}) {
        
         /if (${Me.ActiveDisc.ID} && ${${ArrayName}[${i},${iCastName}].Equal[Savage Spirit]}) /goto :skipCurrent
         /if (${Me.ActiveDisc.ID} && ${${ArrayName}[${i},${iCastType}].Equal[Disc]} && ${Bool[${${ArrayName}[${i},${iDuration}]}]}) /goto :skipCurrent
-        
-        /echo useBurns ${ArrayName}: Issuing cast for  ${${ArrayName}[${i},${iCastName}]}
         /call e3_Cast ${AssistTarget} "${ArrayName}" "${i}" 0
        
         /if (${Select[${castReturn},CAST_SUCCESS]}) {
@@ -1453,10 +1451,17 @@ SUB useBurns(ArrayName)
        
       }
     } else {
-      /echo useBurns ${ArrayName}: NotReady: ${i} ${${ArrayName}[${i},${iCastName}]}
+      /if (${Debug} || ${Debug_Assists}) /echo useBurns ${ArrayName}: NotReady: ${i} ${${ArrayName}[${i},${iCastName}]}
     }
     :skipCurrent
-    |/delay 1
+    /if (${isHealer}) {
+        |interupt stoning if we have someone to heal
+        /call check_HealCasting_DuringDetrimental
+        /if (!${c_SubToRun}) {
+            /break
+        }
+    } 
+
   /next i
 
 /if (${Debug} || ${Debug_Assists}) /echo <== useBurns -|

--- a/Macros/e3 Includes/e3_Assists.inc
+++ b/Macros/e3 Includes/e3_Assists.inc
@@ -71,7 +71,10 @@ SUB event_Assist(line, ChatSender, int MobID)
         } else /if (${AssistType.Equal[ranged]}) {
           /if (${Debug} || ${Debug_Assists}) /echo autofire on
           /squelch /face fast id ${AssistTarget}
-          /if (!${Me.AutoFire}) /autofire on
+          /if (!${Me.AutoFire}) {
+            /delay 1s
+            /autofire
+          } 
           /if (${RangedStickDistance.Equal[Clamp]}) {
             /if (${Target.Distance} >=30 && ${Target.Distance} <=200) {
               /squelch /stick hold moveback ${Target.Distance}
@@ -248,7 +251,10 @@ SUB check_AssistStatus
         } else {
           /squelch /stick hold moveback ${RangedStickDistance}
         }
-        /if (!${Me.AutoFire}) /autofire on
+        /if (!${Me.AutoFire}) {
+            /delay 1s
+            /autofire
+      } 
       }
     } else /if (${AssistType.Equal[Autofire]} && !${pauseRanged}) {
       /squelch /face fast id ${AssistTarget}
@@ -256,10 +262,13 @@ SUB check_AssistStatus
         /squelch /stick moveback 195
       } 
       |keep out of AE rampage range
-      /if (${Target.Distance} < 35) {
-        /squelch /stick moveback 35
+      |/if (${Target.Distance} < 35) {
+       | /squelch /stick moveback 35
+      |} 
+      /if (!${Me.AutoFire}) {
+            /delay 1s
+            /autofire
       } 
-      /if (!${Me.AutoFire}) /autofire on
     }
   }
   /if ((!${Me.Casting.ID} || ${Me.Class.ShortName.Equal[BRD]}) && (${Me.Combat} || ${Me.CombatState.Equal[Combat]} ||  ${AssistTarget} >0 ) && ${Target.ID} == ${AssistTarget} && ${Defined[Abilities2D]}) /call CombatAbilities

--- a/Macros/e3 Includes/e3_Assists.inc
+++ b/Macros/e3 Includes/e3_Assists.inc
@@ -1443,7 +1443,6 @@ SUB useBurns(ArrayName)
         /if (${Me.ActiveDisc.ID} && ${${ArrayName}[${i},${iCastType}].Equal[Disc]} && ${Bool[${${ArrayName}[${i},${iDuration}]}]}) {
            | /echo Currently in disc and duration > 0. Skiping ${${ArrayName}[${i},${iCastName}]}. Duration: ${Bool[${${ArrayName}[${i},${iDuration}]}]} 
            |/echo Burns-Skip: ${i} ${${ArrayName}[${i},${iCastName}]}
-           /delay 1
            /goto :skipCurrent
 
         } 

--- a/Macros/e3 Includes/e3_Assists.inc
+++ b/Macros/e3 Includes/e3_Assists.inc
@@ -252,7 +252,7 @@ SUB check_AssistStatus
       }
     }
   }
-  /if ((!${Me.Casting.ID} || ${Me.Class.ShortName.Equal[BRD]}) && ${Me.Combat} && ${Defined[Abilities2D]}) /call CombatAbilities
+  /if ((!${Me.Casting.ID} || ${Me.Class.ShortName.Equal[BRD]}) && (${Me.Combat} || ${Me.CombatState.Equal[Combat]} ||  ${AssistTarget} >0 ) && ${Defined[Abilities2D]}) /call CombatAbilities
 /if (${Debug} || ${Debug_Assists}) /echo <== check_AssistStatus -|
 /RETURN
 

--- a/Macros/e3 Includes/e3_Assists.inc
+++ b/Macros/e3 Includes/e3_Assists.inc
@@ -1440,7 +1440,7 @@ SUB useBurns(ArrayName)
         /if (${Me.ActiveDisc.ID} && ${${ArrayName}[${i},${iCastName}].Equal[Savage Spirit]}) /goto :skipCurrent
         /if (${Me.ActiveDisc.ID} && ${${ArrayName}[${i},${iCastType}].Equal[Disc]} && ${Bool[${${ArrayName}[${i},${iDuration}]}]}) /goto :skipCurrent
         /call e3_Cast ${AssistTarget} "${ArrayName}" "${i}"
-        /delay 2
+        |/delay 2
         |/varset ActionTaken TRUE
         /call check_Ready "${ArrayName}" ${i}
         /if (!${c_Ready}) /g ${ArrayName}-${${ArrayName}[${i},${iCastName}]}

--- a/Macros/e3 Includes/e3_Assists.inc
+++ b/Macros/e3 Includes/e3_Assists.inc
@@ -1442,7 +1442,7 @@ SUB useBurns(ArrayName)
         /if (${Me.ActiveDisc.ID} && ${${ArrayName}[${i},${iCastName}].Equal[Savage Spirit]}) /goto :skipCurrent
         /if (${Me.ActiveDisc.ID} && ${${ArrayName}[${i},${iCastType}].Equal[Disc]} && ${Bool[${${ArrayName}[${i},${iDuration}]}]}) {
            | /echo Currently in disc and duration > 0. Skiping ${${ArrayName}[${i},${iCastName}]}. Duration: ${Bool[${${ArrayName}[${i},${iDuration}]}]} 
-           /echo Burns-Skip: ${i} ${${ArrayName}[${i},${iCastName}]}
+           |/echo Burns-Skip: ${i} ${${ArrayName}[${i},${iCastName}]}
            /delay 1
            /goto :skipCurrent
 

--- a/Macros/e3 Includes/e3_Assists.inc
+++ b/Macros/e3 Includes/e3_Assists.inc
@@ -1126,7 +1126,7 @@ SUB cast_damageOverTimeSpells(int TargetID, string ArrayName)
             /varset ${resistCount} 0
             /call createTimer "${spellTimer}" "1m"
           }
-        } u
+        }
       | If the spell did not take hold.
       } else /if (${Cast.Stored.Name.Equal[${${ArrayName}[${i},${iSpellName}]}]} && ${castReturn.Equal[CAST_TAKEHOLD]} && !${Cast.Stored.Name.Equal[${spammableSpell}]}) {
         /if (${Defined[${resistCount}]}) {

--- a/Macros/e3 Includes/e3_Assists.inc
+++ b/Macros/e3 Includes/e3_Assists.inc
@@ -1440,7 +1440,12 @@ SUB useBurns(ArrayName)
       /if (${check_Distance[${AssistTarget},${${ArrayName}[${i},${iMyRange}]}]}) {
        
         /if (${Me.ActiveDisc.ID} && ${${ArrayName}[${i},${iCastName}].Equal[Savage Spirit]}) /goto :skipCurrent
-        /if (${Me.ActiveDisc.ID} && ${${ArrayName}[${i},${iCastType}].Equal[Disc]} && ${Bool[${${ArrayName}[${i},${iDuration}]}]}) /goto :skipCurrent
+        /if (${Me.ActiveDisc.ID} && ${${ArrayName}[${i},${iCastType}].Equal[Disc]} && ${Bool[${${ArrayName}[${i},${iDuration}]}]}) {
+            /echo Currently in disc and duration > 0. Skiping ${${ArrayName}[${i},${iCastName}]}. Duration: ${Bool[${${ArrayName}[${i},${iDuration}]}]} 
+            /echo 
+            /goto :skipCurrent
+
+        } 
         /call e3_Cast ${AssistTarget} "${ArrayName}" "${i}" 0
        
         /if (${Select[${castReturn},CAST_SUCCESS]}) {

--- a/Macros/e3 Includes/e3_Assists.inc
+++ b/Macros/e3 Includes/e3_Assists.inc
@@ -325,7 +325,7 @@ SUB CombatAbilities
       |- Discipline, no disc with a duration can go here
     } else /if (${Abilities2D[${i},${iCastType}].Equal[Disc]}) {
     |/echo car ${Me.CombatAbilityReady[${abilityName}]} ${Me.CombatAbility[${abilityName}]} ${abilityName} ${Me.CombatAbilityReady[${abilityName}]} ${Me.CombatAbilityReady[Backstab]}
-      /if (${Me.CombatAbilityReady[${Abilities2D[${i},${iCastName}]}]}) {
+      /if (${Me.CombatAbilityReady[${Abilities2D[${i},${iCastName}]}]} && !${Me.ActiveDisc.Name.Find[${Abilities2D[${i},${iCastName}]}]}) {
         |/echo ${Abilities2D[${i},${iCastName}]} myend ${Me.PctEndurance} >= minend ${Abilities2D[${i},${iMinEnd}]} and endcost ${Spell[${Abilities2D[${i},${iCastName}]}].EnduranceCost} <= ${Me.Endurance}
         /if (${Me.PctEndurance} >= ${Abilities2D[${i},${iMinEnd}]} && ${Spell[${Abilities2D[${i},${iCastName}]}].EnduranceCost} <= ${Me.Endurance} && ${Abilities2D[${i},${iIfs}]}) {
           |/echo ready ${abilityName} ${Me.CombatAbilityReady[${abilityName}]}

--- a/Macros/e3 Includes/e3_Assists.inc
+++ b/Macros/e3 Includes/e3_Assists.inc
@@ -201,9 +201,9 @@ SUB check_AssistStatus
     /if (${AllowControl} || !${Select[${Me.Class.ShortName},NEC,SHD,MNK]}) /stand
   }
   | If the character is macro controlled
-  /if (${AllowControl} && ((${AssistType.Equal[melee]} || ${AssistType.Equal[ranged]}))) {
+  /if (${AllowControl} && ((${AssistType.Equal[melee]} || ${AssistType.Equal[ranged]} || ${AssistType.Equal[Autofire]} ))) {
     | Check Target: this only forces retarget for melee/autofire bots and lets casters/priests do their thing
-    /if (${Target.ID} != ${AssistTarget} && (!${Bool[${Me.Casting}]} || ${Me.Class.ShortName.Equal[BRD]}) && (${AssistType.Equal[melee]} || ${AssistType.Equal[ranged]})) /call TrueTarget ${AssistTarget}
+    /if (${Target.ID} != ${AssistTarget} && (!${Bool[${Me.Casting}]} || ${Me.Class.ShortName.Equal[BRD]}) && (${AssistType.Equal[melee]} || ${AssistType.Equal[ranged]}|| ${AssistType.Equal[Autofire]} )) /call TrueTarget ${AssistTarget}
     |----- Melee functions-------------------------------------------------------------------------------------------------------------|
       /if (${AssistType.Equal[Melee]} || ${pauseRanged}) {
         /if (${isEnraged}) {

--- a/Macros/e3 Includes/e3_Assists.inc
+++ b/Macros/e3 Includes/e3_Assists.inc
@@ -250,6 +250,10 @@ SUB check_AssistStatus
         }
         /if (!${Me.AutoFire}) /autofire on
       }
+    } else /if (${AssistType.Equal[Autofire]} && !${pauseRanged}) {
+      /squelch /face fast id ${AssistTarget}
+      |dont play chase
+      /if (!${Me.AutoFire}) /autofire on
     }
   }
   /if ((!${Me.Casting.ID} || ${Me.Class.ShortName.Equal[BRD]}) && (${Me.Combat} || ${Me.CombatState.Equal[Combat]} ||  ${AssistTarget} >0 ) && ${Defined[Abilities2D]}) /call CombatAbilities

--- a/Macros/e3 Includes/e3_Assists.inc
+++ b/Macros/e3 Includes/e3_Assists.inc
@@ -1453,7 +1453,7 @@ SUB useBurns(ArrayName)
         /if (${Select[${castReturn},CAST_SUCCESS]}) {
           /g ${ArrayName}-${${ArrayName}[${i},${iCastName}]}
         } else {
-          /g ${castReturn}: ${ArrayName}-${${ArrayName}[${i},${iCastName}]}
+          |/g ${castReturn}: ${ArrayName}-${${ArrayName}[${i},${iCastName}]}
         }
        
       }

--- a/Macros/e3 Includes/e3_Assists.inc
+++ b/Macros/e3 Includes/e3_Assists.inc
@@ -1463,8 +1463,9 @@ SUB useBurns(ArrayName)
     :skipCurrent
     /if (${isHealer}) {
         |interupt stoning if we have someone to heal
-        /call check_HealCasting_DuringDetrimental
+        /call check_HealCasting_DuringBurns
         /if (!${c_SubToRun}) {
+          	/echo [${Time}]: useBurns: ${ArrayName}: healer needs to heal jumping out of burn.
             /break
         }
     } 

--- a/Macros/e3 Includes/e3_Assists.inc
+++ b/Macros/e3 Includes/e3_Assists.inc
@@ -261,6 +261,8 @@ SUB check_AssistStatus
 |- e3_casting is not used, for performance, as these are short recast low impact only
 |------------------------------------------------|
 SUB CombatAbilities
+
+  
   /if (${Debug} || ${Debug_Assists}) /echo |- CombatAbilities ==>
   /declare i int local
   | Prereq/priorities
@@ -282,10 +284,11 @@ SUB CombatAbilities
           |   /doability "Bazu Bellow"
           } else /if (${Me.AltAbilityReady[Divine Stun]}) {
             /bc Divine Stun on ${Target.CleanName}: ${Me.TargetOfTarget.Class.ShortName}-${Me.TargetOfTarget} has aggro
-            /casting "Divine Stun"
+            /call castSimpleSpell "Divine Stun" ${Target.ID}
+
           } else /if (${Me.SpellReady[Terror of Discord]}) {
             /bc Terror of Discord on ${Target.CleanName}: ${Me.TargetOfTarget.Class.ShortName}-${Me.TargetOfTarget} has aggro
-            /casting "Terror of Discord"
+            /call castSimpleSpell "Terror of Discord" ${Target.ID}
           }
         }
       }
@@ -302,18 +305,22 @@ SUB CombatAbilities
       /goto :skipAbility
     }
     /if (${Abilities2D[${i},${iCastType}].Equal[Ability]}) {
+
       /if (${Abilities2D[${i},${iCastName}].Equal[Bash]}) {
         /if (!${Select[${Me.Inventory[Offhand].Type},Shield]} && !${Me.AltAbility[2 Hand Bash]}) /goto :skipAbility
+        |can't do anything if stunned.
+        /if (${Me.Stunned}) /goto :skipAbility
+        /if (${Target.Distance} >10) /goto :skipAbility
+        
       }
       /if (${Me.AbilityReady[${Abilities2D[${i},${iCastName}]}]}) {
-        /doability "${Abilities2D[${i},${iCastName}]}"
-        /delay 2 !${Me.AbilityReady[${Abilities2D[${i},${iCastName}]}]}
+        
+        /call castSimpleSpell "${Abilities2D[${i},${iCastName}]}" 0
       }
       |- AA, only those with 0 cast time can go here
     } else /if (${Abilities2D[${i},${iCastType}].Equal[AA]}) {
       /if (${Me.AltAbilityReady[${Abilities2D[${i},${iCastName}]}]}) {
-        /casting "${Abilities2D[${i},${iCastName}]}" alt
-        /delay 3 !${Me.AltAbilityReady[${Abilities2D[${i},${iCastName}]}]}
+        /call castSimpleSpell "${Abilities2D[${i},${iCastName}]}" 0
       }
       |- Discipline, no disc with a duration can go here
     } else /if (${Abilities2D[${i},${iCastType}].Equal[Disc]}) {
@@ -322,8 +329,8 @@ SUB CombatAbilities
         |/echo ${Abilities2D[${i},${iCastName}]} myend ${Me.PctEndurance} >= minend ${Abilities2D[${i},${iMinEnd}]} and endcost ${Spell[${Abilities2D[${i},${iCastName}]}].EnduranceCost} <= ${Me.Endurance}
         /if (${Me.PctEndurance} >= ${Abilities2D[${i},${iMinEnd}]} && ${Spell[${Abilities2D[${i},${iCastName}]}].EnduranceCost} <= ${Me.Endurance} && ${Abilities2D[${i},${iIfs}]}) {
           |/echo ready ${abilityName} ${Me.CombatAbilityReady[${abilityName}]}
-          /disc ${Abilities2D[${i},${iCastName}]}
-          /delay 3 !${Me.CombatAbilityReady[${Abilities2D[${i},${iCastName}]}]}
+          /call castSimpleSpell "${Abilities2D[${i},${iCastName}]}" 0
+          
         }
       }
     }
@@ -427,14 +434,7 @@ SUB check_Nukes
       }
     } else {
 
-      |When an item delay is applied to an entry, check to see if the delay is still active
-      |Check lower comment after the spell is cast for more information.
-      /if (${Defined[nukeSpellRecast_${Nukes2D[${castIndex},${iSpellID}]}]}) {
-        /if (${nukeSpellRecast_${Nukes2D[${castIndex},${iSpellID}]}}) {
-          |/bc check_nuke: skipping nukes as its timer isn't met yet:${Nukes2D[${castIndex},${iCastName}]} time left:${nukeSpellRecast_${Nukes2D[${castIndex},${iSpellID}]}}
-          /goto :skipCast
-        }
-      }
+     
       | skip casting if a delay is defined and active
       /if (${Defined[castDelay${Nukes2D[${castIndex},${iCastID}]}]}) {
         /if (${castDelay${Nukes2D[${castIndex},${iCastID}]}}) {
@@ -467,13 +467,6 @@ SUB check_Nukes
         /if (!${Nukes2D[${i},${iCastName}].Equal[${currentCastName}]}) {
           
           /call check_Ready "Nukes2D" ${i}
-          |When an item delay is applied to an entry, check to see if the delay is still active
-          |Check lower comment after the spell is cast for more information.
-          /if (${Defined[nukeSpellRecast_${Nukes2D[${i},${iSpellID}]}]}) {
-            /if (${nukeSpellRecast_${Nukes2D[${i},${iSpellID}]}}) {
-              /varset c_Ready FALSE
-            }
-          }
           /if (${c_Ready} && ${Nukes2D[${i},${iIfs}]}) {
             /if (${Bool[${Nukes2D[${i},${iGiftOfMana}]}]}) {
               |its specified to use gift of mana, well do we have it?
@@ -580,16 +573,9 @@ SUB check_Nukes
       }
       
 
-      /if (${Select[${castReturn},CAST_SUCCESS]} && ${typeOfCast.Equal[Item]}) {
-          |when an item is click/cast, the server sends over the cooldown of said item
-          |so for a breif time between clicking there is an 'unkown' state where the items
-          |cooldown is still 0, even tho it isn't valid. Noticed this when using molten orbs.
-          |Adding a small delay to any item that is cast to prevent it from being a valid target
-          |on the next event cycle as event cycles in e3 are far faster than the server can send us
-          |the cooldown information
-          /call CreateTimer nukeSpellRecast_${Nukes2D[${castIndex},${iSpellID}]} "1s"
-      }
+     
       |if the nuke was succesful, see if there is a delay defined and create a timer which locks out all nukes for the duration
+      |mainly used for PBAOE stuns
       /if (${Bool[${Nukes2D[${castIndex},${iDelay}]}]} && ${Select[${castReturn},CAST_SUCCESS]}) {
         /if (${Debug} || ${Debug_Assists}) /echo delaying ${Nukes2D[${castIndex},${iCastName}]} for ${Nukes2D[${castIndex},${iDelay}]}
         /call CreateTimer "castDelay${Nukes2D[${castIndex},${iCastID}]}" "${Nukes2D[${castIndex},${iDelay}]}"
@@ -1135,8 +1121,8 @@ SUB cast_damageOverTimeSpells(int TargetID, string ArrayName)
           /if (${${resistCount}} >= ${${ArrayName}[${i},${iMaxTries}]}) {
             /varset ${resistCount} 0
             /call createTimer "${spellTimer}" "1m"
-        }
-      }
+          }
+        } u
       | If the spell did not take hold.
       } else /if (${Cast.Stored.Name.Equal[${${ArrayName}[${i},${iSpellName}]}]} && ${castReturn.Equal[CAST_TAKEHOLD]} && !${Cast.Stored.Name.Equal[${spammableSpell}]}) {
         /if (${Defined[${resistCount}]}) {

--- a/Macros/e3 Includes/e3_Assists.inc
+++ b/Macros/e3 Includes/e3_Assists.inc
@@ -1441,9 +1441,10 @@ SUB useBurns(ArrayName)
        
         /if (${Me.ActiveDisc.ID} && ${${ArrayName}[${i},${iCastName}].Equal[Savage Spirit]}) /goto :skipCurrent
         /if (${Me.ActiveDisc.ID} && ${${ArrayName}[${i},${iCastType}].Equal[Disc]} && ${Bool[${${ArrayName}[${i},${iDuration}]}]}) {
-            /echo Currently in disc and duration > 0. Skiping ${${ArrayName}[${i},${iCastName}]}. Duration: ${Bool[${${ArrayName}[${i},${iDuration}]}]} 
-            /echo 
-            /goto :skipCurrent
+           | /echo Currently in disc and duration > 0. Skiping ${${ArrayName}[${i},${iCastName}]}. Duration: ${Bool[${${ArrayName}[${i},${iDuration}]}]} 
+           /echo Burns-Skip: ${i} ${${ArrayName}[${i},${iCastName}]}
+           /delay 1
+           /goto :skipCurrent
 
         } 
         /call e3_Cast ${AssistTarget} "${ArrayName}" "${i}" 0

--- a/Macros/e3 Includes/e3_Assists.inc
+++ b/Macros/e3 Includes/e3_Assists.inc
@@ -333,8 +333,9 @@ SUB CombatAbilities
         |/echo ${Abilities2D[${i},${iCastName}]} myend ${Me.PctEndurance} >= minend ${Abilities2D[${i},${iMinEnd}]} and endcost ${Spell[${Abilities2D[${i},${iCastName}]}].EnduranceCost} <= ${Me.Endurance}
         /if (${Me.PctEndurance} >= ${Abilities2D[${i},${iMinEnd}]} && ${Spell[${Abilities2D[${i},${iCastName}]}].EnduranceCost} <= ${Me.Endurance} && ${Abilities2D[${i},${iIfs}]}) {
           |/echo ready ${abilityName} ${Me.CombatAbilityReady[${abilityName}]}
-          /call castSimpleSpell "${Abilities2D[${i},${iCastName}]}" 0
-          
+          /if (!(${Me.ActiveDisc.ID} && ${Abilities2D[${i},${iCastType}].Equal[Disc]} && ${Spell[${Abilities2D[${i},${iCastName}]}].TargetType.Equal[Self]})) {
+              /call castSimpleSpell "${Abilities2D[${i},${iCastName}]}" 0
+          }
         }
       }
     }
@@ -1440,9 +1441,10 @@ SUB useBurns(ArrayName)
       /if (${check_Distance[${AssistTarget},${${ArrayName}[${i},${iMyRange}]}]}) {
        
         /if (${Me.ActiveDisc.ID} && ${${ArrayName}[${i},${iCastName}].Equal[Savage Spirit]}) /goto :skipCurrent
-        /if (${Me.ActiveDisc.ID} && ${${ArrayName}[${i},${iCastType}].Equal[Disc]} && ${Bool[${${ArrayName}[${i},${iDuration}]}]}) {
+        /if (${Me.ActiveDisc.ID} && ${${ArrayName}[${i},${iCastType}].Equal[Disc]} && ${Spell[${${ArrayName}[${i},${iCastName}]}].TargetType.Equal[Self]}) {
            | /echo Currently in disc and duration > 0. Skiping ${${ArrayName}[${i},${iCastName}]}. Duration: ${Bool[${${ArrayName}[${i},${iDuration}]}]} 
            |/echo Burns-Skip: ${i} ${${ArrayName}[${i},${iCastName}]}
+         
            /goto :skipCurrent
 
         } 

--- a/Macros/e3 Includes/e3_Assists.inc
+++ b/Macros/e3 Includes/e3_Assists.inc
@@ -252,7 +252,13 @@ SUB check_AssistStatus
       }
     } else /if (${AssistType.Equal[Autofire]} && !${pauseRanged}) {
       /squelch /face fast id ${AssistTarget}
-      |dont play chase
+      /if (${Target.Distance} > 200) {
+        /squelch /stick moveback 195
+      } 
+      |keep out of AE rampage range
+      /if (${Target.Distance} < 35) {
+        /squelch /stick moveback 35
+      } 
       /if (!${Me.AutoFire}) /autofire on
     }
   }

--- a/Macros/e3 Includes/e3_Basics.inc
+++ b/Macros/e3 Includes/e3_Basics.inc
@@ -2083,7 +2083,7 @@ SUB check_Supply
 			/varset supplyGem ${Supply[${i}].Arg[4,|]}
 			/if (!${Defined[SupplyTimer${i}]}) /declare SupplyTimer${i} timer outer 0
 			/if (!${Bool[${FindItem[=${supplyItem}]}]} && ${SupplyTimer${i}} == 0) {
-				/echo ==> Supply: Creating a ${supplyItem} using ${supplySpell}
+				/echo [${Time}]: Supply: Creating a ${supplyItem} using ${supplySpell}
 				/delay 1
 				/tar ${Me}
 				/delay 1
@@ -2107,13 +2107,13 @@ SUB check_Supply
            /call check_ReadySimple "${supplySpell}"
            /if (${c_Ready}) {
 
-            /echo Supply trying to get a:"${supplySpell}" 
+            /echo [${Time}]: Supply trying to get a:"${supplySpell}" 
             /call castSimpleSpell "${supplySpell}" ${Me.ID}
 
            }
            
        	} else {
-           /echo Supply with Gem specific: ${supplySpell}/Gem|${supplyGem}
+           /echo [${Time}]: Supply with Gem specific: ${supplySpell}/Gem|${supplyGem}
            /call check_ReadySimple "${supplySpell}" ${supplyGem}
            /if (${c_Ready}) {
               /call castSimpleSpellBase "${supplySpell}/Gem|${supplyGem}" ${Me.ID} False

--- a/Macros/e3 Includes/e3_Basics.inc
+++ b/Macros/e3 Includes/e3_Basics.inc
@@ -1944,30 +1944,7 @@ sub notifyViaBCTell(targetToTell, messageToSend)
     }
 
 /return
-|--------------------------------------------------------------------------------------------|
-|- Used to call the e3_Cast for simple spells that cannot normally fail.                   	-|
-|--------------------------------------------------------------------------------------------|
-sub castSimpleSpell(spellNameToBase, simpleTargetIDToBase)
 
-    /call castSimpleSpellBase "${spellNameToBase}" ${simpleTargetIDToBase} True
-
-/return
-sub castSimpleSpellBase(spellName, simpleTargetID, SkipParams)
-
-  /if (${simpleTargetID}==0) {
-    |if 0 passed in, set it to whatever they are targeting
-    /varset simpleTargetID ${Target.ID}
-  }
-    |/echo building the spell array for heirlooms
-  /call BuildSingleSpellArrayBase "${spellName}" "castSimpleSpellArray2D" ${SkipParams}
-   
-    /call e3_Cast ${simpleTargetID} "castSimpleSpellArray2D" 1 False
-    /while (${Select[${castReturn},CAST_FIZZLE]}) {
-          /delay 1s
-          /call e3_Cast  ${simpleTargetID} "castSimpleSpellArray2D" 1 False
-    }
-
-/return
 |----------------------------------------------------------------------------|
 |- Whenever nothing else is going on will check if the toon has all the items in the gimme list
 |- and request items it doesn't have from the target character
@@ -2071,7 +2048,7 @@ SUB check_Supply
   /if (${Me.Combat}) /goto :endsupply
   /if (${Assisting}) /goto :endsupply
   /if (${Me.PctAggro} > 0) /goto :endsupply
-  
+ 
   /if (${Me.PctMana} == 100 && ${Me.PctHPs} == 100 ) { 
 		
     /if (!${Defined[Supply]}) /call IniToArrayV "${Character_Ini},Supply,Supply#" Supply
@@ -2109,11 +2086,23 @@ SUB check_Supply
 				}
 
 				/if (${supplyGem} == 0 || ${supplyGem} == NULL) { 
-           /echo Supply trying to get a:"${supplySpell}" 
-           /call castSimpleSpell "${supplySpell}" ${Me.ID}
+           
+           /call check_ReadySimple "${supplySpell}"
+           /if (${c_Ready}) {
+
+            /echo Supply trying to get a:"${supplySpell}" 
+            /call castSimpleSpell "${supplySpell}" ${Me.ID}
+
+           } else {
+             /echo Supply trying to get a:"${supplySpell}" failed for check_readySimplme
+           }
+           
        	} else {
            /echo Supply with Gem specific: ${supplySpell}/Gem|${supplyGem}
-           /call castSimpleSpellBase "${supplySpell}/Gem|${supplyGem}" ${Me.ID} False
+           /call check_ReadySimple "${supplySpell}" ${supplyGem}
+           /if (${c_Ready}) {
+              /call castSimpleSpellBase "${supplySpell}/Gem|${supplyGem}" ${Me.ID} False
+           }
 				}
 				/delay 20s ${Cursor.ID}
         /call ClearCursor

--- a/Macros/e3 Includes/e3_Basics.inc
+++ b/Macros/e3 Includes/e3_Basics.inc
@@ -2649,9 +2649,7 @@ sub check_PreviousSpell
 Sub check_Basics
   /call check_ResistCounters
   /call check_PreviousSpell
-  /if (${Me.Class.ShortName.Equal[BRD]}) {
-              /call check_BardSongs
-  }
+  
 
 /return
 

--- a/Macros/e3 Includes/e3_Basics.inc
+++ b/Macros/e3 Includes/e3_Basics.inc
@@ -2649,6 +2649,9 @@ sub check_PreviousSpell
 Sub check_Basics
   /call check_ResistCounters
   /call check_PreviousSpell
+  /if (${Me.Class.ShortName.Equal[BRD]}) {
+              /call check_BardSongs
+  }
 
 /return
 

--- a/Macros/e3 Includes/e3_Basics.inc
+++ b/Macros/e3 Includes/e3_Basics.inc
@@ -1171,23 +1171,20 @@ SUB EVENT_gate(line, ChatSender)
   /if (!${Me.Book[gate]}) {
     /if (${FindItem[Philter of Major Translocation].ID}) {
       /docommand ${ChatToggle} Preparing to gate...
-      /casting "Philter of Major Translocation" -maxtries|2
+      /call castSimpleSpell "Philter of Major Translocation" ${Me.ID}
     } else /if (${FindItem[Vial of Swirling Smoke].ID}) {
       /docommand ${ChatToggle} Preparing to gate...
-      /casting "Vial of Swirling Smoke" -maxtries|2
+      /call castSimpleSpell "Vial of Swirling Smoke" ${Me.ID}
     } else /if (${FindItem[Gate Potion].ID}) {
       /docommand ${ChatToggle} Preparing to gate...
-      /casting "Gate Potion" -maxtries|2
+      /call castSimpleSpell "Gate Potion" ${Me.ID}
     } else {
       /docommand ${ChatToggle} I am not able to gate at this time.
     }
   } else {
     /docommand ${ChatToggle} Preparing to gate...
-    /call interrupt
-    /delay 3s !${Me.Casting.ID}
-    /casting "Gate" -maxtries|2
-    /delay 3s !${Me.Casting.ID}
-  }
+    /call castSimpleSpell "Gate" ${Me.ID}
+   }
 /RETURN 
 
 |--------------------------------------------------------|
@@ -1210,15 +1207,13 @@ SUB EVENT_Evacuate(line, ChatSender)
       /delay 3
       /docommand ${ChatToggle} Evacuating!
       /call interrupt
-      /delay 3s !${Me.Casting.ID}
-      /casting "Exodus" alt
+      /call castSimpleSpell "Exodus" ${Me.ID}
+	  
     } else /if (${Me.Book[${Evac_Spell.Arg[1,/]}]}) {
       /docommand ${ChatToggle} Evacuating!
       /call interrupt
-      /delay 3s !${Me.Casting.ID}
-      /casting "${Evac_Spell.Arg[1,/]}" -maxtries|2
-      /delay 3s !${Me.Casting.ID}
-    } else {
+      /call castSimpleSpell "${Evac_Spell.Arg[1,/]}" ${Me.ID}
+	} else {
       /docommand ${ChatToggle} I am not able to Evac at this time.
     }
   }
@@ -1959,6 +1954,10 @@ sub castSimpleSpell(spellNameToBase, simpleTargetIDToBase)
 /return
 sub castSimpleSpellBase(spellName, simpleTargetID, SkipParams)
 
+  /if (${simpleTargetID}==0) {
+    |if 0 passed in, set it to whatever they are targeting
+    /varset simpleTargetID ${Target.ID}
+  }
   /if (${Defined[castSimpleSpellArray]}) /deletevar castSimpleSpellArray
   /declare castSimpleSpellArray[1] string outer ${spellName}
   /if (${castSimpleSpellArray.Size}) {
@@ -2119,7 +2118,6 @@ SUB check_Supply
        	} else {
            /echo Supply with Gem specific: ${supplySpell}/Gem|${supplyGem}
            /call castSimpleSpellBase "${supplySpell}/Gem|${supplyGem}" ${Me.ID} False
-					 |/casting "${supplySpell}" ${supplyGem}
 				}
 				/delay 20s ${Cursor.ID}
         /call ClearCursor

--- a/Macros/e3 Includes/e3_Basics.inc
+++ b/Macros/e3 Includes/e3_Basics.inc
@@ -1840,28 +1840,45 @@ sub event_gimme(line, ChatSender, RequestedItem)
 		/if (${Bool[${Me.Book[${RequestedItem}]}]} || ${Bool[${Me.AltAbility[${RequestedItem}]}]}) {
 
 			/if (${DebugGimme}) /echo casting "${RequestedItem}"
-			/call castSimpleSpell "${RequestedItem}" ${Me.ID}
-     
+        /call check_ReadySimple "${RequestedItem}"
+        /if (${c_Ready}) {
+          /call castSimpleSpell "${RequestedItem}" ${Me.ID}
+        }     
     } else /if (${Bool[${Me.Book[Summon: ${RequestedItem}]}]}) {
 
 			/if (${DebugGimme}) /echo casting "Summon: ${RequestedItem}"
-      /call castSimpleSpell "Summon: ${RequestedItem}" ${Me.ID}
+      /call check_ReadySimple "Summon: ${RequestedItem}"
+      /if (${c_Ready}) {
+        /call castSimpleSpell "Summon: ${RequestedItem}" ${Me.ID}
+      }
+    
 		
 		} else /if (${Bool[${Me.Book[Summon ${RequestedItemStringWithoutSummoned}]}]}) {
 		
     	/if (${DebugGimme}) /echo casting "Summon ${RequestedItemStringWithoutSummoned}"
-      /call castSimpleSpell "Summon ${RequestedItemStringWithoutSummoned}" ${Me.ID}
+  
+      /call check_ReadySimple "Summon ${RequestedItemStringWithoutSummoned}"
+      /if (${c_Ready}) {
+        /call castSimpleSpell "Summon ${RequestedItemStringWithoutSummoned}" ${Me.ID}
+      }
     	/varset SummonSpellCast "Summon ${RequestedItemStringWithoutSummoned}"
 		
     } else /if (${Bool[${Me.Book[${RequestedItemStringWithoutSummoned}]}]} || ${Bool[${Me.AltAbility[${RequestedItemStringWithoutSummoned}]}]}) {
 		
     	/if (${DebugGimme}) /echo casting ${RequestedItemStringWithoutSummoned}
-	    /call castSimpleSpell "${RequestedItemStringWithoutSummoned}" ${Me.ID}
+      /call check_ReadySimple "${RequestedItemStringWithoutSummoned}"
+      /if (${c_Ready}) {
+        /call castSimpleSpell "${RequestedItemStringWithoutSummoned}" ${Me.ID}
+      }      
+	   
   
   	} else /if (${Bool[${RequestedItem.Find[Sanguine Mind Crystal]}]} && ${Bool[${Me.AltAbility[Sanguine Mind Crystal]}]}) {
 			/if (${DebugGimme}) /echo casting Sanguine Mind Crystal
-
-      /call castSimpleSpell "Sanguine Mind Crystal" ${Me.ID}
+      /call check_ReadySimple "Sanguine Mind Crystal"
+      /if (${c_Ready}) {
+         /call castSimpleSpell "Sanguine Mind Crystal" ${Me.ID}
+      }          
+     
 			
 		} else {
 			/delay 2s

--- a/Macros/e3 Includes/e3_Basics.inc
+++ b/Macros/e3 Includes/e3_Basics.inc
@@ -1958,19 +1958,15 @@ sub castSimpleSpellBase(spellName, simpleTargetID, SkipParams)
     |if 0 passed in, set it to whatever they are targeting
     /varset simpleTargetID ${Target.ID}
   }
-  /if (${Defined[castSimpleSpellArray]}) /deletevar castSimpleSpellArray
-  /declare castSimpleSpellArray[1] string outer ${spellName}
-  /if (${castSimpleSpellArray.Size}) {
     |/echo building the spell array for heirlooms
-    /call BuildSpellArrayBase "castSimpleSpellArray" "castSimpleSpellArray2D" ${SkipParams}
+  /call BuildSingleSpellArrayBase "${spellName}" "castSimpleSpellArray2D" ${SkipParams}
    
     /call e3_Cast ${simpleTargetID} "castSimpleSpellArray2D" 1 False
     /while (${Select[${castReturn},CAST_FIZZLE]}) {
           /delay 1s
           /call e3_Cast  ${simpleTargetID} "castSimpleSpellArray2D" 1 False
     }
-    /if (${Defined[castSimpleSpellArray]}) /deletevar castSimpleSpellArray
-  }
+
 /return
 |----------------------------------------------------------------------------|
 |- Whenever nothing else is going on will check if the toon has all the items in the gimme list

--- a/Macros/e3 Includes/e3_Basics.inc
+++ b/Macros/e3 Includes/e3_Basics.inc
@@ -2622,6 +2622,25 @@ SUB ItemDeleteSummoned(ItemString)
     } 
 
 /RETURN
+
+|--------------------
+|Method currently used in bard twisting, but can be useful for other areas.
+|takes a snapshot of spells that were cast (non insta casts), to be used for later. 
+|possibly update e3cast to also update this, but was written to be used with /twist
+|as it doesn't go through e3_Cast
+|------------------
+sub check_PreviousSpell
+
+  /if (!${Bool[${Me.Casting.ID}]}) /return
+  /declare currentSpellCasting int local 0
+  /varset currentSpellCasting ${Me.Gem[${Me.Casting}]}
+
+  /if (${Bool[${currentSpellCasting}]}) {
+    /varset previousSpellGemThatWasCast ${currentSpellCasting}
+  }
+
+/return
+
 |---------------------------------------------------------------------------------|
 | Centralized area to call methods that will be called every event loop
 | Warning only put things that check very quickly if they should be called or not.
@@ -2629,4 +2648,8 @@ SUB ItemDeleteSummoned(ItemString)
 |---------------------------------------------------------------------------------|
 Sub check_Basics
   /call check_ResistCounters
+  /call check_PreviousSpell
+
 /return
+
+

--- a/Macros/e3 Includes/e3_Basics.inc
+++ b/Macros/e3 Includes/e3_Basics.inc
@@ -2110,8 +2110,6 @@ SUB check_Supply
             /echo Supply trying to get a:"${supplySpell}" 
             /call castSimpleSpell "${supplySpell}" ${Me.ID}
 
-           } else {
-             /echo Supply trying to get a:"${supplySpell}" failed for check_readySimplme
            }
            
        	} else {

--- a/Macros/e3 Includes/e3_BuffCheck.inc
+++ b/Macros/e3 Includes/e3_BuffCheck.inc
@@ -143,8 +143,9 @@ SUB meleeCombatBuffs(ArrayName, int s)
               /if (${c_Ready}) {
                 /if (${buffTargetID}!=${Me.ID}) /call TrueTarget ${buffTargetID}
                 /delay 1
-                /disc ${${ArrayName}[${s},${iCastName}]}
-                /delay 1
+                /call castSimpleSpell "${${ArrayName}[${s},${iCastName}]}" 0
+                |/disc ${${ArrayName}[${s},${iCastName}]}
+                |/delay 3
               }
           }
         }
@@ -223,8 +224,7 @@ SUB checkAuras
       /declare previousSpell string local ${Me.Gem[${DefaultGem}]}
       /call check_Ready "auraSpells2D" 1
       /if (${c_Ready}) {
-        /cast ${Me.Gem[${auraSpells2D[1,${iCastName}]}]}
-        /delay 7s !${Me.Casting.ID}
+        /call castSimpleSpell "${auraSpells2D[1,${iCastName}]}" 0
         /if (${Bool[${previousSpell}]}) {
           /echo Re-memorizing ${previousSpell} after aura cast
           /memorize "${previousSpell}" "${DefaultGem}"

--- a/Macros/e3 Includes/e3_BuffCheck.inc
+++ b/Macros/e3 Includes/e3_BuffCheck.inc
@@ -3,7 +3,7 @@
 |--------------------------------------------------------------------------------|
 SUB check_Buffs
 	/if (${Debug} || ${Debug_BuffCheck}) /echo |- buffCheck ==>
-	/if (${BuffCheck} && !${ActionTaken} && !${activeTimer} && !${rebuffTimer}) {
+  	/if (${BuffCheck} && !${ActionTaken} && !${activeTimer} && !${rebuffTimer}) {
 		/if (!${idle} && ${BuffCombatCheck} && !${Me.Moving} && ${Assisting})	/call buffBots "CombatBuffs2D"
 		/if (${procBuff} && !${idle} && !${Me.Moving} && ${Assisting}) /call buffProcs
 		/if (${Defined[auraSpells2D]} && (${auraCombat} || ${Me.CombatState.NotEqual[COMBAT]}) && !${Me.Moving}) /call checkAuras
@@ -219,18 +219,50 @@ SUB checkAuras
     /if (!${ActionTaken})  /next s
   } else /if (!${Bool[${Me.Aura[1]}]}) {
     /if (${Me.Class.ShortName.Equal[BRD]}) {
-      /if (${Twist.Twisting}) /call pauseTwist
-      /if (${Me.Casting.ID}) /call interrupt
+     
+      /if (${songPlayer.Equal["MQ2Twist"]}) {
+        
+        /if (${Twist.Twisting}) /call pauseTwist
+        /if (${Me.Casting.ID}) /call interrupt
+
+      } else {
+        |tap the current gem if we are casting 
+        /if (${Bool[${Me.Casting.ID}]} ) {
+          /delay 1
+          /stopcast
+        }
+      }
       /declare previousSpell string local ${Me.Gem[${DefaultGem}]}
+
+      
+
+      /memorize "${auraSpells2D[1,${iCastName}]}" "${DefaultGem}"
+
+      |a delay check, for sync 
+      /while (!${Me.SpellReady[${auraSpells2D[1,${iCastName}]}]}) {
+       /delay 1
+      } 
+      /delay 1
+
       /call check_Ready "auraSpells2D" 1
       /if (${c_Ready}) {
-        /call castSimpleSpell "${auraSpells2D[1,${iCastName}]}" 0
+        /cast "${auraSpells2D[1,${iCastName}]}"
+        /delay 3
+        /while (${Window[CastingWindow].Open}) {
+          /delay 1
+        }
+        /delay 3
         /if (${Bool[${previousSpell}]}) {
           /echo Re-memorizing ${previousSpell} after aura cast
           /memorize "${previousSpell}" "${DefaultGem}"
         }
       }
-      /call unpauseTwist
+      /if (${songPlayer.Equal["MQ2Twist"]}) {
+        
+        /call unpauseTwist
+
+      }
+      
     } else {
       /declare previousSpell string local ${Me.Gem[${DefaultGem}]}
       /call check_Ready "auraSpells2D" 1

--- a/Macros/e3 Includes/e3_BuffCheck.inc
+++ b/Macros/e3 Includes/e3_BuffCheck.inc
@@ -226,9 +226,13 @@ SUB checkAuras
         /if (${Me.Casting.ID}) /call interrupt
 
       } else {
+
+        /while (${Window[CastingWindow].Open}) {
+          /delay 1
+        }
+        /delay 1
         |tap the current gem if we are casting 
         /if (${Bool[${Me.Casting.ID}]} ) {
-          /delay 1
           /stopcast
         }
       }

--- a/Macros/e3 Includes/e3_Casting.inc
+++ b/Macros/e3 Includes/e3_Casting.inc
@@ -30,6 +30,7 @@ Sub e3_Cast(int targetID, ArrayName, int ArrayIndex, bool StopEchos)
 |StopEchos = Skips the /echo on successful cast if a value other than 0 is passed with the /call e3_Cast
 /if (${Debug} || ${Debug_Casting}) /echo |- e3_Cast ==>
 
+	/varset castReturn  
 	|if we are a bard, and not doing async twisting this section of code
 	|will 'block' as the check_BardSongs does not block on its call.
 	|this allows other check_ Methods to run to do their computation while the spell is running
@@ -269,7 +270,26 @@ Sub e3_Cast(int targetID, ArrayName, int ArrayIndex, bool StopEchos)
 		}
 		
 		/if (${${ArrayName}[${ArrayIndex},${iTargetType}].Equal[Self]}) {
-			/casting "${pendingCast}|${pendingType}"
+			
+			|bards songs don't work with /casting, have to do it ourselves
+			/if (${Bool[${Me.Book[${pendingCast}]}]} && ${Me.Class.ShortName.Equal[BRD]}) {
+				/echo e3_Cast issuing a raw cast for :"${pendingCast}"
+				/cast "${pendingCast}"
+                /delay 5 ${Window[CastingWindow].Open}
+                /if (!${Window[CastingWindow].Open}) {
+					/echo e3_Cast issuing stopcast as cast window isn't open
+			        /stopcast
+                    /delay 1
+                    /cast ${pendingCast}
+                    /delay 3
+                }
+
+                /varset castReturn CAST_SUCCESS
+                /varset ActionTaken True
+
+			} else {
+				/casting "${pendingCast}|${pendingType}"
+			}
 			/delay 3
 			/declare castWindowWaitCounter int local 0
 			/if (${e3_CastTime}>500) {
@@ -286,31 +306,29 @@ Sub e3_Cast(int targetID, ArrayName, int ArrayIndex, bool StopEchos)
 					}
 				}
 			}
-			|**/if (${pendingType.Equal[Item]}) {
-				/delay 3
-			} else {
-				/delay 5
-			}**|	
-			|**/if (${pendingType.Equal[Item]}) {
-
-				/useitem "${pendingCast}"
-				|set to a default good value unless overwritten for a reason
-				/varset castReturn CAST_SUCCESS
-				|Note when using /useitem, if the next 'cast' is a spell you need a 0.3 sec delay similar to bard songs.
-				|Possible optimizations to pass in to use the delay or not, but be warned, not using the delay
-				|and the spell is the next can get you to a point where your spell gems lock up and need to use an AA to fix.
-				/delay 3
-				
-
-			} else {
-				/casting "${pendingCastID}|${pendingType}"
-				/delay 3		
-			}**|
-
-		} else {
-			|/echo /casting "${pendingCast}|${pendingType}" "-targetid|${targetID}"
 			
-			/casting "${pendingCast}|${pendingType}" "-targetid|${targetID}"
+		} else {
+			
+			|bards songs don't work with /casting, have to do it ourselves
+			/if (${Bool[${Me.Book[${pendingCast}]}]} && ${Me.Class.ShortName.Equal[BRD]}) {
+				/cast "${pendingCast}"
+               
+                /delay 5 ${Window[CastingWindow].Open}
+                
+                /if (!${Window[CastingWindow].Open}) {
+                    /stopcast
+                    /delay 1
+                    /cast ${pendingCast}
+                    /delay 3
+                }
+
+                /varset castReturn CAST_SUCCESS
+                /varset ActionTaken True
+
+			} else {
+				/casting "${pendingCast}|${pendingType}" "-targetid|${targetID}"
+			}
+			
 			|delay 3 is enough time to have result come back with fizzle
 			/delay 3
 			/declare castWindowWaitCounter int local 0
@@ -329,37 +347,6 @@ Sub e3_Cast(int targetID, ArrayName, int ArrayIndex, bool StopEchos)
 				}
 			}
 			
-			|**/if (${pendingType.Equal[Item]}) {
-				/delay 3
-			} else {
-				/delay 5
-			}**|		
-			|**/if (${pendingType.Equal[Item]}) {
-				/declare i_target int local 0
-				|/echo getting tareget for item
-				/for i 1 to 5
-					/if (${Bool[${Target.ID} != ${targetID}]}) {
-						/target id ${targetID}
-						/delay 1
-					} else {
-						|ExitLoop if target is correct
-						/break
-				}
-				/next i_target
-				|/echo casting item "${pendingCast}" on ${targetID}
-				/useitem "${pendingCast}"
-				|set to a default good value unless overwritten for a reason
-				/varset castReturn CAST_SUCCESS
-				|Note when using /useitem, if the next 'cast' is a spell you need a 0.3 sec delay similar to bard songs.
-				|Possible optimizations to pass in to use the delay or not, but be warned, not using the delay
-				|and the spell is the next can get you to a point where your spell gems lock up and need to use an AA to fix.
-				/delay 3
-				|set to a default good value unless overwritten for a reason
-				
-			} else {
-				/casting "${pendingCastID}|${pendingType}" "-targetid|${targetID}"
-				/delay 3
-			}**|
 		}
 		|- Memorizing spell
 		/if (${Cast.Status.Find[M]}) /delay 3s !${Cast.Status.Find[M]}
@@ -486,31 +473,34 @@ Sub e3_Cast(int targetID, ArrayName, int ArrayIndex, bool StopEchos)
 		}
 		
   :interrupted
-		|At this point the cast window is closed, but we may need to delay to get the result. 
-		|note, if we don't find the result in 2 seconds, soemthing has gone wrong
-		|it will use the previous cast return instead. There is a bug here for item lockups
-		|so we let this continue to loop back around and remove the item lock
-		/delay 2s !${Cast.Status.Find[C]}
-		/varset castReturn ${Cast.Result}
-		|- Cast Result Processing
-		  /if (${castReturn.Equal[CAST_INTERRUPTED]} || ${interruptFlag}) {
-			/varset castReturn CAST_INTERRUPTED
-		} else /if (${castReturn.Equal[CAST_SUCCESS]}) {
-			/varset lastSuccessfulCast ${pendingCast}
-		} else /if (${castReturn.Equal[CAST_RESIST]}) {
-			/if (${Debug_Casting} && ${Target.ID}) /docommand ${ChatToggle} ** ${Target.Name} resisted ${pendingCast} **
-		} else /if (${castReturn.Equal[CAST_IMMUNE]}) {
-      /docommand ${ChatToggle} ${Target.Name} is immune to ${pendingCast} **
-			/varset immuneList ${immuneList}${pendingCastID}_${castTargetName},
-    |dont create a nohold timer for detrimental AE spells
-		} else /if (${castReturn.Equal[CAST_TAKEHOLD]} && ${Select[${ArrayName},TargetAE_Spells2D,PBAE_Spells2D]}==0) {
-     		 /if (${Target.ID}==${targetID}) {
-				/docommand ${ChatToggle} ** ${pendingCast} did not take hold on ${castTargetName} **
-       			/call CreateTimer "nht${targetID}-${pendingCastID}" "${noHoldDelay}"
+		|only check casting if its not a bard spell, as it uses raw /cast
+		/if (!(${Bool[${Me.Book[${pendingCast}]}]} && ${Me.Class.ShortName.Equal[BRD]})) { 
+			|At this point the cast window is closed, but we may need to delay to get the result. 
+			|note, if we don't find the result in 2 seconds, soemthing has gone wrong
+			|it will use the previous cast return instead. There is a bug here for item lockups
+			|so we let this continue to loop back around and remove the item lock
+			/delay 2s !${Cast.Status.Find[C]}
+			/varset castReturn ${Cast.Result}
+			|- Cast Result Processing
+				/if (${castReturn.Equal[CAST_INTERRUPTED]} || ${interruptFlag}) {
+				/varset castReturn CAST_INTERRUPTED
+			} else /if (${castReturn.Equal[CAST_SUCCESS]}) {
+				/varset lastSuccessfulCast ${pendingCast}
+			} else /if (${castReturn.Equal[CAST_RESIST]}) {
+				/if (${Debug_Casting} && ${Target.ID}) /docommand ${ChatToggle} ** ${Target.Name} resisted ${pendingCast} **
+			} else /if (${castReturn.Equal[CAST_IMMUNE]}) {
+			/docommand ${ChatToggle} ${Target.Name} is immune to ${pendingCast} **
+				/varset immuneList ${immuneList}${pendingCastID}_${castTargetName},
+			|dont create a nohold timer for detrimental AE spells
+			} else /if (${castReturn.Equal[CAST_TAKEHOLD]} && ${Select[${ArrayName},TargetAE_Spells2D,PBAE_Spells2D]}==0) {
+					/if (${Target.ID}==${targetID}) {
+					/docommand ${ChatToggle} ** ${pendingCast} did not take hold on ${castTargetName} **
+					/call CreateTimer "nht${targetID}-${pendingCastID}" "${noHoldDelay}"
+				}
+			} else /if (${Select[${castReturn},CAST_OUTDOORS,CAST_COMPONENTS,CAST_UNKNOWN]}) {
+				/docommand ** ${ChatToggle} Adding to failureList due to Return Events CAST_OUTDOORS,CAST_COMPONENT,CAST_UNKNOWN
+				/varset failureList ${failureList}${pendingCastID},		
 			}
-		} else /if (${Select[${castReturn},CAST_OUTDOORS,CAST_COMPONENTS,CAST_UNKNOWN]}) {
-			/docommand ** ${ChatToggle} Adding to failureList due to Return Events CAST_OUTDOORS,CAST_COMPONENT,CAST_UNKNOWN
-			/varset failureList ${failureList}${pendingCastID},		
 		}
   }
 

--- a/Macros/e3 Includes/e3_Casting.inc
+++ b/Macros/e3 Includes/e3_Casting.inc
@@ -579,10 +579,12 @@ Sub check_Ready(ArrayName, int ArrayIndex)
   | Memorize the spell if it is not memorized
   
   /if (${${ArrayName}[${ArrayIndex},${iCastType}].Equal[Spell]}) {
+ 
     /if (!${Bool[${Me.Gem[${${ArrayName}[${ArrayIndex},${iCastName}]}]}]}) {
  		/call memorize_spell "${${ArrayName}[${ArrayIndex},${iCastName}]}" ${${ArrayName}[${ArrayIndex},${iSpellGem}]}
 	}
 	/if (${Me.SpellReady[${${ArrayName}[${ArrayIndex},${iCastName}]}]}) /varset c_Ready TRUE
+ 
   } else /if (${${ArrayName}[${ArrayIndex},${iCastType}].Equal[Item]}) {
 	|Need to check if we already have this item on cooldown
 	/declare itemID int local ${FindItem[=${${ArrayName}[${ArrayIndex},${iCastName}]}].ID}
@@ -638,7 +640,7 @@ Sub check_ReadySimple(spellName, gemToUse)
   /if (${spellType.Equal[Spell]}) {
     /if (!${Bool[${Me.Gem[${spellName}]}]}) {
 		/declare tempGemNum int local ${DefaultGem}
-		/if (${Bool[gemTouse]}) {
+		/if (${Bool[${gemToUse}]}) {
 			/varset tempGemNum ${gemToUse}
 		}
 		/call memorize_spell "${spellName}" ${tempGemNum}

--- a/Macros/e3 Includes/e3_Casting.inc
+++ b/Macros/e3 Includes/e3_Casting.inc
@@ -627,7 +627,7 @@ Sub memorize_spell(spellName,gemNum)
 	/declare waitForReady timer local ${timeTowait}
 	|/echo wfr ${waitForReady} rc ${Spell[${spellName}].RecastTime} math ${Math.Calc[25+(${Spell[${spellName}].RecastTime}/100)]}
 	:checkTimer
-		/echo memorize_spell waiting on spell being ready
+		
 		|/echo chectimer ${waitForReady} ${Me.SpellReady[${spellName}]}
 		/if (${waitForReady}) {
 		/doevents Follow

--- a/Macros/e3 Includes/e3_Casting.inc
+++ b/Macros/e3 Includes/e3_Casting.inc
@@ -362,6 +362,7 @@ Sub e3_Cast(int targetID, ArrayName, int ArrayIndex, bool StopEchos)
 		}
 		|- Memorizing spell
 		/if (${Cast.Status.Find[M]}) /delay 3s !${Cast.Status.Find[M]}
+
 		|- Set expected cast end time in 1/10ths of a second
 		/varcalc castEndTime ${Me.Casting.MyCastTime}/100
 		|/echo checking if window is open
@@ -572,9 +573,12 @@ Sub check_Ready(ArrayName, int ArrayIndex)
   /if (${Debug} || ${Debug_Casting}) /echo |- check_Ready =>
   /varset c_Ready FALSE
   | Memorize the spell if it is not memorized
+  
   /if (${${ArrayName}[${ArrayIndex},${iCastType}].Equal[Spell]}) {
-    /if (!${Bool[${Me.Gem[${${ArrayName}[${ArrayIndex},${iCastName}]}]}]}) /call memorize_spell "${${ArrayName}[${ArrayIndex},${iCastName}]}" ${${ArrayName}[${ArrayIndex},${iSpellGem}]}
-    /if (${Me.SpellReady[${${ArrayName}[${ArrayIndex},${iCastName}]}]}) /varset c_Ready TRUE
+    /if (!${Bool[${Me.Gem[${${ArrayName}[${ArrayIndex},${iCastName}]}]}]}) {
+ 		/call memorize_spell "${${ArrayName}[${ArrayIndex},${iCastName}]}" ${${ArrayName}[${ArrayIndex},${iSpellGem}]}
+	}
+	/if (${Me.SpellReady[${${ArrayName}[${ArrayIndex},${iCastName}]}]}) /varset c_Ready TRUE
   } else /if (${${ArrayName}[${ArrayIndex},${iCastType}].Equal[Item]}) {
 	|Need to check if we already have this item on cooldown
 	/declare itemID int local ${FindItem[=${${ArrayName}[${ArrayIndex},${iCastName}]}].ID}
@@ -610,24 +614,31 @@ Sub check_Ready(ArrayName, int ArrayIndex)
 
 Sub memorize_spell(spellName,gemNum)
   /if (${Debug} || ${Debug_Casting}) /echo |- memorize_spell =>
-  /memorize "${spellName}" ${gemNum}
-	/delay 3s ${Bool[${Me.Gem[${spellName}]}]}
+  	/memorize "${spellName}" ${gemNum}
+	/delay 5s ${Bool[${Me.Gem[${spellName}]}]}
+	
 	|only wait for beneficial,self spells
-	/if (${Spell[${spellName}].Beneficial} || ${Spell[${spellName}].TargetType.Equal[Self]}) {
-    /declare waitForReady timer local ${If[${Me.CombatState.Equal[COMBAT]},35,${Math.Calc[35+(${Spell[${spellName}].RecastTime}/100)]}]}
-    |/echo wfr ${waitForReady} rc ${Spell[${spellName}].RecastTime} math ${Math.Calc[25+(${Spell[${spellName}].RecastTime}/100)]}
-    :checkTimer
-      |/echo chectimer ${waitForReady} ${Me.SpellReady[${spellName}]}
-      /if (${waitForReady}) {
-      /doevents Follow
-      /doevents Stop
-      /doevents MoveHere
-      /doevents BackOff
-      /call alerts_Background_Events
-      /delay 1
-      /if (!${Me.SpellReady[${spellName}]}) /goto :checkTimer
-		}
+	|(${Me.Combat} || ${Me.CombatState.Equal[Combat]} ||  ${AssistTarget} >0)
+
+	/declare timeTowait int local ${Math.Calc[35+(${Spell[${spellName}].RecastTime}/100)]}
+	/if ((${Me.Combat} || ${Me.CombatState.Equal[Combat]} ||  ${AssistTarget} >0)) {
+		/varset timeTowait 30
 	}
+	/declare waitForReady timer local ${timeTowait}
+	|/echo wfr ${waitForReady} rc ${Spell[${spellName}].RecastTime} math ${Math.Calc[25+(${Spell[${spellName}].RecastTime}/100)]}
+	:checkTimer
+		/echo memorize_spell waiting on spell being ready
+		|/echo chectimer ${waitForReady} ${Me.SpellReady[${spellName}]}
+		/if (${waitForReady}) {
+		/doevents Follow
+		/doevents Stop
+		/doevents MoveHere
+		/doevents BackOff
+		/call alerts_Background_Events
+		/delay 1
+		/if (!${Me.SpellReady[${spellName}]}) /goto :checkTimer
+	}
+	
   /if (${Debug} || ${Debug_Casting}) /echo |- memorize_spell <=
 /RETURN
 |------------------------------------------------|
@@ -958,13 +969,20 @@ sub castSimpleSpell(spellNameToBase, simpleTargetIDToBase)
 /return
 sub castSimpleSpellBase(spellName, simpleTargetID, SkipParams)
 
-  /if (${simpleTargetID}==0) {
-    |if 0 passed in, set it to whatever they are targeting
-    /varset simpleTargetID ${Target.ID}
-  }
-    |/echo building the spell array for heirlooms
-    /call BuildSingleSpellArrayBase "${spellName}" "castSimpleSpellArray2D" ${SkipParams}
-   
+	/if (${simpleTargetID}==0) {
+		|if 0 passed in, set it to whatever they are targeting
+		/varset simpleTargetID ${Target.ID}
+	}
+   	
+	/call BuildSingleSpellArrayBase "${spellName}" "castSimpleSpellArray2D" ${SkipParams}
+  
+	/call check_Ready "castSimpleSpellArray2D" 1
+    /while (!${c_Ready}) {
+		/delay 3
+		/echo checkready not ready, waiting
+		/call check_Ready "castSimpleSpellArray2D" 1		
+	}
+	
     /call e3_Cast ${simpleTargetID} "castSimpleSpellArray2D" 1 False
     /while (${Select[${castReturn},CAST_FIZZLE]}) {
           /delay 1s

--- a/Macros/e3 Includes/e3_Casting.inc
+++ b/Macros/e3 Includes/e3_Casting.inc
@@ -48,11 +48,18 @@ Sub e3_Cast(int targetID, ArrayName, int ArrayIndex, bool StopEchos)
   |if im invis and iCastInvis=0 (default except for heals)
   |if im a rog, not in combat, done no action for 10+ seconds, and near 2+ other players then drop invis to buff (allows autohide)
   
-  /if ( ${Me.Class.ShortName.Equal[BRD]} && ${Bool[${Me.Casting.ID}]} && !${${ArrayName}[${ArrayIndex},${iCastType}].Equal[Ability]} && !${${ArrayName}[${ArrayIndex},${iCastType}].Equal[Disc]} ) {
+  /if (!${Twist.Twisting} && ${Me.Class.ShortName.Equal[BRD]} && ${Bool[${Me.Casting.ID}]} && !${${ArrayName}[${ArrayIndex},${iCastType}].Equal[Ability]} && !${${ArrayName}[${ArrayIndex},${iCastType}].Equal[Disc]} ) {
     |turn off our current song so that items and other things can be clicked
-     /cast ${Me.Gem[${Me.Casting}]}
+	 /if (${Bool[${Me.Gem[${Me.Casting}]}]}) {
+		 /echo doing a spell click off
+ 		/cast ${Me.Gem[${Me.Casting}]}
+	} else {
+		|an item cast most likely, we have to click some valid gem
+		/echo doing an item click off
+		/cast 1
+	}
   }
-
+  
   |CatchAll Function for potentially locked up spell gems.
   /if (!${Select[${Me.Class.ShortName},WAR,ROG,MNK,BER]}) {
   	/call check_SpellGemLockup

--- a/Macros/e3 Includes/e3_Casting.inc
+++ b/Macros/e3 Includes/e3_Casting.inc
@@ -181,7 +181,7 @@ Sub e3_Cast(int targetID, ArrayName, int ArrayIndex, bool StopEchos)
 	|~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	|Use Disc
 	/if (${${ArrayName}[${ArrayIndex},${iCastType}].Equal[Disc]}) {
-		/if (${Me.ActiveDisc.ID} && ${${ArrayName}[${ArrayIndex},${iDuration}]}) {
+		/if (${Me.ActiveDisc.ID} && ${Spell[${${ArrayName}[${ArrayIndex},${iCastName}]}].TargetType.Equal[Self]}) {
 			/if (${Debug} || ${Debug_Casting}) /echo Skipping ${ArrayName}[${ArrayIndex},${iCastName}, Waiting on disc [${Window[CombatAbilityWnd].Child[CAW_CombatEffectLabel].Text}]
 			/varset castReturn ACTIVEDISC
 			/goto :skipCast

--- a/Macros/e3 Includes/e3_Casting.inc
+++ b/Macros/e3 Includes/e3_Casting.inc
@@ -32,6 +32,7 @@ Sub e3_Cast(int targetID, ArrayName, int ArrayIndex, bool StopEchos)
 	/varset pendingCast		${${ArrayName}[${ArrayIndex},${iCastName}]}
 	/varset pendingCastID	${${ArrayName}[${ArrayIndex},${iCastID}]}
 	/declare castTargetName string local ${Spawn[id ${targetID}].CleanName}
+	/declare e3_CastTime int local ${${ArrayName}[${ArrayIndex},${iMyCastTime}]}
 	/varset castEndTime		0
   /varset castReturn		0
 	/varset interruptFlag FALSE
@@ -51,8 +52,6 @@ Sub e3_Cast(int targetID, ArrayName, int ArrayIndex, bool StopEchos)
   /if (!${Select[${Me.Class.ShortName},WAR,ROG,MNK,BER]}) {
   	/call check_SpellGemLockup
   }
-
-	  
   
   /if (${Me.Invis}) {
     /if (${Me.Class.ShortName.Equal[Rog]}) {
@@ -142,12 +141,6 @@ Sub e3_Cast(int targetID, ArrayName, int ArrayIndex, bool StopEchos)
     }
   }
 
-	/if (${Twist.Twisting}) {
-		|this sets returnTwist to true
-		/call pauseTwist
-		/delay 3s !${Me.Casting.ID}
-		/delay 3
-	} 
 	
 
 	/declare startingLoc ${Me.Loc.Replace[ ,]}
@@ -155,7 +148,10 @@ Sub e3_Cast(int targetID, ArrayName, int ArrayIndex, bool StopEchos)
 |  Casting
 :cast_spell
   |/if (${Me.Name.Equal[Lube]}) /gu Casting ${pendingCast} ${pendingCastID} ${Spawn[id ${targetID}].Name} ${targetID}
-	/if (!${StopEchos}) /echo [${Time}]: ${pendingCast} ${pendingCastID} ${Spawn[id ${targetID}].Name} ${targetID}
+	/if (!${${ArrayName}[${ArrayIndex},${iCastType}].Equal[Ability]}) {
+		
+		/if (!${StopEchos}) /echo [${Time}]: ${pendingCast} ${pendingCastID} ${Spawn[id ${targetID}].Name} ${targetID}  (${Math.Calc[${e3_CastTime}/1000]}sec)
+	}
 	|~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	|Use Disc
 	/if (${${ArrayName}[${ArrayIndex},${iCastType}].Equal[Disc]}) {
@@ -184,7 +180,18 @@ Sub e3_Cast(int targetID, ArrayName, int ArrayIndex, bool StopEchos)
 	|-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	|- Spells, AA, Items
 	} else {
-			|- Stop following for spell/item/aa with a cast time > 0 MyCastTime, unless im a bard
+
+		|if bard and the spell/item you are casting is > 0.3 sec stop what we are doing
+		/if (${Select[${Me.Class.ShortName},BRD]} && ${e3_CastTime} >0) {
+			/if (${Twist.Twisting}) {
+				|this sets returnTwist to true
+				/call pauseTwist
+				/delay 3s !${Me.Casting.ID}
+				/delay 3
+			} 
+		}
+	
+		|- Stop following for spell/item/aa with a cast time > 0 MyCastTime, unless im a bard
 		/if (${${ArrayName}[${ArrayIndex},${iMyCastTime}]} >0 && ${Me.Class.ShortName.NotEqual[BRD]}) {
 			/if (${Stick.Status.Equal[on]}) /squelch /stick pause
 			/if (${NetAdvPath.Following} && ${Following}) /squelch /netfollow off

--- a/Macros/e3 Includes/e3_Casting.inc
+++ b/Macros/e3 Includes/e3_Casting.inc
@@ -371,6 +371,7 @@ Sub e3_Cast(int targetID, ArrayName, int ArrayIndex, bool StopEchos)
 |- check for reasons to cancel casting
 		
 		/if (${Window[CastingWindow].Open}) {
+		   /varset c_SubToRun True
 		  |dont allow item swap/must equip interrupts to avoid crashes
 			|/echo checking is still open
 		   	/if (${Me.Class.ShortName.Equal[BRD]}) {
@@ -414,7 +415,7 @@ Sub e3_Cast(int targetID, ArrayName, int ArrayIndex, bool StopEchos)
 				/if (!${g_CastNowSpellCasting} && (!${c_SubToRun})) {
 							/echo [${Time}]: E3_Cast nowCast called interrupt ${${ArrayName}[${ArrayIndex},${iSubToRun}]}
 							/call interrupt
-							/delay 1s
+							/delay 3
 							/varset castReturn CAST_INTERRUPTED
 							/goto :skipCast
 				}

--- a/Macros/e3 Includes/e3_Casting.inc
+++ b/Macros/e3 Includes/e3_Casting.inc
@@ -266,9 +266,13 @@ Sub e3_Cast(int targetID, ArrayName, int ArrayIndex, bool StopEchos)
 			}
 			}
 		}
-
+		
 		/if (${${ArrayName}[${ArrayIndex},${iTargetType}].Equal[Self]}) {
-			/if (${Bool[${FindItem[=${pendingCast}]}]}) {
+			/casting "${pendingCast}|${pendingType}"
+			/if (${pendingType.Equal[Item]}) {
+				/delay 3
+			}		
+			|**/if (${Bool[${FindItem[=${pendingCast}]}]}) {
 
 				/useitem "${pendingCast}"
 				|set to a default good value unless overwritten for a reason
@@ -281,8 +285,14 @@ Sub e3_Cast(int targetID, ArrayName, int ArrayIndex, bool StopEchos)
 
 			} else {
 				/casting "${pendingCastID}|${pendingType}"		
-			}
+			}**|
+
 		} else {
+			/casting "${pendingCast}|${pendingType}" "-targetid|${targetID}"
+			/if (${pendingType.Equal[Item]}) {
+				/delay 3
+			}	
+			|**			
 			/if (${Bool[${FindItem[=${pendingCast}]}]}) {
 				/declare i_target int local 0
 				|/echo getting tareget for item
@@ -307,7 +317,7 @@ Sub e3_Cast(int targetID, ArrayName, int ArrayIndex, bool StopEchos)
 				
 			} else {
 				/casting "${pendingCastID}|${pendingType}" "-targetid|${targetID}"
-			}
+			}**|
 		}
 		|- Memorizing spell
 		/if (${Cast.Status.Find[M]}) /delay 3s !${Cast.Status.Find[M]}
@@ -458,13 +468,10 @@ Sub e3_Cast(int targetID, ArrayName, int ArrayIndex, bool StopEchos)
 
 	|to help with item clicks locking up, to give the server time to issue the cooldown.	
 	/if (${Select[${castReturn},CAST_SUCCESS]} && ${pendingType.Equal[item]}) {
-			|when an item is click/cast, the server sends over the cooldown of said item
-			|so for a breif time between clicking there is an 'unknown' state where the items
-			|cooldown is still 0, even tho it isn't valid. Noticed this when using molten orbs.
-			|Adding a small delay to any item that is cast to prevent it from being a valid target
-			|on the next event cycle as event cycles in e3 are far faster than the server can send us
-			|the cooldown information
-			|/echo e3_Cast: Setting spell recast timer of 2 seconds
+	
+			|sometimes cooldowns are not just properly registered or there is a delay
+			|add small cooldown of default 2 seconds, unless we know the cooldown of the item 
+			|and we just set it ourselves.
 			/call casting_ItemCooldown "${pendingCast}"
 			/declare itemRecastToUseInSeconds int ${Macro.Return}
 
@@ -817,7 +824,7 @@ Sub casting_Setup
 			/varset itemCooldownLookupList[${index},2]  ${tempItemLookupList[${index},2]}
 	/next index
 
-	
+	/echo Items to keep timers on.
 	/for index 1 to ${itemCooldownLookupList.Size[1]}
 
 		/echo ${index} ) ${itemCooldownLookupList[${index},1]}

--- a/Macros/e3 Includes/e3_Casting.inc
+++ b/Macros/e3 Includes/e3_Casting.inc
@@ -184,7 +184,7 @@ Sub e3_Cast(int targetID, ArrayName, int ArrayIndex, bool StopEchos)
 				/delay 5 ${Target.ID} == ${targetID}
 			}
 			/varset ActionTaken TRUE
-			/disc "${pendingCast}""
+			/disc "${pendingCast}"
 			/delay 3
 		}
 	|-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/Macros/e3 Includes/e3_Casting.inc
+++ b/Macros/e3 Includes/e3_Casting.inc
@@ -48,6 +48,11 @@ Sub e3_Cast(int targetID, ArrayName, int ArrayIndex, bool StopEchos)
   |if im invis and iCastInvis=0 (default except for heals)
   |if im a rog, not in combat, done no action for 10+ seconds, and near 2+ other players then drop invis to buff (allows autohide)
   
+  /if ( ${Me.Class.ShortName.Equal[BRD]} && ${Bool[${Me.Casting.ID}]} && !${${ArrayName}[${ArrayIndex},${iCastType}].Equal[Ability]} && !${${ArrayName}[${ArrayIndex},${iCastType}].Equal[Disc]} ) {
+    |turn off our current song so that items and other things can be clicked
+     /cast ${Me.Gem[${Me.Casting}]}
+  }
+
   |CatchAll Function for potentially locked up spell gems.
   /if (!${Select[${Me.Class.ShortName},WAR,ROG,MNK,BER]}) {
   	/call check_SpellGemLockup

--- a/Macros/e3 Includes/e3_Casting.inc
+++ b/Macros/e3 Includes/e3_Casting.inc
@@ -59,6 +59,7 @@ Sub e3_Cast(int targetID, ArrayName, int ArrayIndex, bool StopEchos)
 	/varset pendingCastID ${${ArrayName}[${ArrayIndex},${iCastID}]}
 	/declare castTargetName string local ${Spawn[id ${targetID}].CleanName}
 	/declare e3_CastTime int local ${${ArrayName}[${ArrayIndex},${iMyCastTime}]}
+	/declare e3_CastNoInterrupt bool local ${${ArrayName}[${ArrayIndex},${iNoInterrupt}]}
 	/varset castEndTime	0
 	/varset castReturn 0
 	/varset interruptFlag FALSE
@@ -377,13 +378,16 @@ Sub e3_Cast(int targetID, ArrayName, int ArrayIndex, bool StopEchos)
 		   }
 		 	
 
-		  /if (${oldItem.Length}) {
-		    /delay 1
-		    /goto :cast_still_pending
-		  }
+			/if (${oldItem.Length} || ${e3_CastNoInterrupt}) {
+				/delay 1
+				/goto :cast_still_pending
+			}
+
 			/if (!${interruptFlag}) {
 			   |- Run SubToRun
 			    |/varset Debug_Casting TRUE
+				|allow nothing to interrupt this.
+			
 				/if (${Bool[${${ArrayName}[${ArrayIndex},${iSubToRun}]}]}) {
 					
 					|call interrupt check

--- a/Macros/e3 Includes/e3_Casting.inc
+++ b/Macros/e3 Includes/e3_Casting.inc
@@ -46,6 +46,14 @@ Sub e3_Cast(int targetID, ArrayName, int ArrayIndex, bool StopEchos)
 | Checks to abort casting due to previous failures
   |if im invis and iCastInvis=0 (default except for heals)
   |if im a rog, not in combat, done no action for 10+ seconds, and near 2+ other players then drop invis to buff (allows autohide)
+  
+  |CatchAll Function for potentially locked up spell gems.
+  /if (!${Select[${Me.Class.ShortName},WAR,ROG,MNK,BER]}) {
+  	/call check_SpellGemLockup
+  }
+
+	  
+  
   /if (${Me.Invis}) {
     /if (${Me.Class.ShortName.Equal[Rog]}) {
       /if (!${Me.Combat} && ${SpawnCount[pc radius 40]} > 2 && !${SpawnCount[npc radius 100 zradius 100]} && ${idleTimer}<${Math.Calc[${idleInterval}*600 - 100]}) /makemevisible
@@ -601,4 +609,30 @@ SUB casting_CharacterSettings
 /return
 
 Sub casting_Aliases
+/return
+
+SUB check_SpellGemLockup
+	/declare UnlockSpell string local Origin
+
+	/if (!${Me.AltAbilityReady[${UnlockSpell}]}) {
+		/varset UnlockSpell "Marr's Calling"
+	}
+
+	/if (${Bool[${Me.Casting.ID}]} && !${Window[CastingWindow].Open} && !${Me.SpellInCooldown}) {
+		/if (${Me.AltAbilityReady[${UnlockSpell}]}) {
+			/bc ${Me.CleanName}'s spell gems are locked! Attempting unlock.
+			/alt act ${Me.AltAbility[${UnlockSpell}].ID}
+
+			/while (${Me.Casting.ID}) {
+				/if (${Me.Mount.ID}) {
+					/dismount
+				}
+				/interrupt
+				/stopcast
+				/delay 1
+			}
+		} else {
+			/bc ${Me.CleanName}'s spell gems are locked! ${UnlockSpell} is not up!
+		}
+	}
 /return

--- a/Macros/e3 Includes/e3_Casting.inc
+++ b/Macros/e3 Includes/e3_Casting.inc
@@ -613,9 +613,17 @@ Sub casting_Aliases
 
 SUB check_SpellGemLockup
 	/declare UnlockSpell string local Origin
+	/declare checkCounter int local 0
 
 	/if (!${Me.AltAbilityReady[${UnlockSpell}]}) {
 		/varset UnlockSpell "Marr's Calling"
+	}
+	
+	|if we are stuck in this sitaution, delay for 0.3 sec to see if we will self correct before we do
+	|anything drastic
+	/while ((${Bool[${Me.Casting.ID}]} && !${Window[CastingWindow].Open} && !${Me.SpellInCooldown}) && ${checkCounter} < 3) {
+		/delay 1
+		/varcalc checkCounter ${checkCounter}+1 
 	}
 
 	/if (${Bool[${Me.Casting.ID}]} && !${Window[CastingWindow].Open} && !${Me.SpellInCooldown}) {

--- a/Macros/e3 Includes/e3_Casting.inc
+++ b/Macros/e3 Includes/e3_Casting.inc
@@ -269,12 +269,27 @@ Sub e3_Cast(int targetID, ArrayName, int ArrayIndex, bool StopEchos)
 		
 		/if (${${ArrayName}[${ArrayIndex},${iTargetType}].Equal[Self]}) {
 			/casting "${pendingCast}|${pendingType}"
-			/if (${pendingType.Equal[Item]}) {
+			/delay 3
+			/declare castWindowWaitCounter int local 0
+			/if (${e3_CastTime}>500) {
+				/while (!${Window[CastingWindow].Open}) {
+					/if (${Cast.Result.Equal[CAST_FIZZLE]}) {
+						/echo window not open yet, but we have a fizzle set..breaking
+						/break
+					}
+					/delay 1
+					/varcalc castWindowWaitCounter ${castWindowWaitCounter}+1
+					|if its taking longer than 2 sec to open a window we have an issue exit
+					/if (${castWindowWaitCounter} > 20) {
+						/break
+					}
+				}
+			}
+			|**/if (${pendingType.Equal[Item]}) {
 				/delay 3
 			} else {
 				/delay 5
-			}		
-			
+			}**|	
 			|**/if (${pendingType.Equal[Item]}) {
 
 				/useitem "${pendingCast}"
@@ -293,12 +308,31 @@ Sub e3_Cast(int targetID, ArrayName, int ArrayIndex, bool StopEchos)
 
 		} else {
 			|/echo /casting "${pendingCast}|${pendingType}" "-targetid|${targetID}"
+			
 			/casting "${pendingCast}|${pendingType}" "-targetid|${targetID}"
-			/if (${pendingType.Equal[Item]}) {
+			|delay 3 is enough time to have result come back with fizzle
+			/delay 3
+			/declare castWindowWaitCounter int local 0
+			/if (${e3_CastTime}>500) {
+				/while (!${Window[CastingWindow].Open}) {
+					/if (${Cast.Result.Equal[CAST_FIZZLE]}) {
+						/echo window not open yet, but we have a fizzle set..breaking
+						/break
+					}
+					/delay 1
+					/varcalc castWindowWaitCounter ${castWindowWaitCounter}+1
+					|if its taking longer than 2 sec to open a window we have an issue exit
+					/if (${castWindowWaitCounter} > 20) {
+						/break
+					}
+				}
+			}
+			
+			|**/if (${pendingType.Equal[Item]}) {
 				/delay 3
 			} else {
 				/delay 5
-			}		
+			}**|		
 			|**/if (${pendingType.Equal[Item]}) {
 				/declare i_target int local 0
 				|/echo getting tareget for item
@@ -330,11 +364,13 @@ Sub e3_Cast(int targetID, ArrayName, int ArrayIndex, bool StopEchos)
 		/if (${Cast.Status.Find[M]}) /delay 3s !${Cast.Status.Find[M]}
 		|- Set expected cast end time in 1/10ths of a second
 		/varcalc castEndTime ${Me.Casting.MyCastTime}/100
+		|/echo checking if window is open
 :cast_still_pending
 |- check for reasons to cancel casting
+		
 		/if (${Window[CastingWindow].Open}) {
 		  |dont allow item swap/must equip interrupts to avoid crashes
-
+			|/echo checking is still open
 		   	/if (${Me.Class.ShortName.Equal[BRD]}) {
 				 /call ActivateSelosKick
 		   }
@@ -433,15 +469,13 @@ Sub e3_Cast(int targetID, ArrayName, int ArrayIndex, bool StopEchos)
 			}
 			/goto :cast_still_pending
 		}
-		|let the window fuly close
-		/delay 1
+		
   :interrupted
 		|At this point the cast window is closed, but we may need to delay to get the result. 
 		|note, if we don't find the result in 2 seconds, soemthing has gone wrong
 		|it will use the previous cast return instead. There is a bug here for item lockups
 		|so we let this continue to loop back around and remove the item lock
 		/delay 2s !${Cast.Status.Find[C]}
-	
 		/varset castReturn ${Cast.Result}
 		|- Cast Result Processing
 		  /if (${castReturn.Equal[CAST_INTERRUPTED]} || ${interruptFlag}) {
@@ -500,11 +534,11 @@ Sub e3_Cast(int targetID, ArrayName, int ArrayIndex, bool StopEchos)
 		/call CastAfterBeforeSpell "${afterSpell}"
 	}
 
-|/varset Debug_Casting FALSE
+	|/varset Debug_Casting FALSE
 	|sometimes cast status gets locked up
 	|lets kill the current cast.
 	
-
+	|/echo Exiting e3_Cast with result : ${castReturn}
 /return
 
 
@@ -929,7 +963,7 @@ sub castSimpleSpellBase(spellName, simpleTargetID, SkipParams)
     /varset simpleTargetID ${Target.ID}
   }
     |/echo building the spell array for heirlooms
-  /call BuildSingleSpellArrayBase "${spellName}" "castSimpleSpellArray2D" ${SkipParams}
+    /call BuildSingleSpellArrayBase "${spellName}" "castSimpleSpellArray2D" ${SkipParams}
    
     /call e3_Cast ${simpleTargetID} "castSimpleSpellArray2D" 1 False
     /while (${Select[${castReturn},CAST_FIZZLE]}) {

--- a/Macros/e3 Includes/e3_Casting.inc
+++ b/Macros/e3 Includes/e3_Casting.inc
@@ -67,9 +67,7 @@ Sub e3_Cast(int targetID, ArrayName, int ArrayIndex, bool StopEchos)
    
 
   |CatchAll Function for potentially locked up spell gems.
-  /if (!${Select[${Me.Class.ShortName},WAR,ROG,MNK,BER]}) {
-  	/call check_SpellGemLockup
-  }
+  /call check_SpellGemLockup
   
   /if (${Me.Invis}) {
     /if (${Me.Class.ShortName.Equal[Rog]}) {
@@ -193,7 +191,7 @@ Sub e3_Cast(int targetID, ArrayName, int ArrayIndex, bool StopEchos)
 		/if (${Me.AbilityReady[${pendingCast}]}) {
       	   /varset ActionTaken TRUE
 			/doability "${pendingCast}"
-			/delay 3 !${Me.AbilityReady[${pendingCast}]}
+			/delay 5 !${Me.AbilityReady[${pendingCast}]}
     	}
 	|-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	|- Spells, AA, Items

--- a/Macros/e3 Includes/e3_Casting.inc
+++ b/Macros/e3 Includes/e3_Casting.inc
@@ -202,8 +202,29 @@ Sub e3_Cast(int targetID, ArrayName, int ArrayIndex, bool StopEchos)
 	} else /if (${${ArrayName}[${ArrayIndex},${iCastType}].Equal[Ability]}) {
 		/if (${Me.AbilityReady[${pendingCast}]}) {
       	   /varset ActionTaken TRUE
-			/doability "${pendingCast}"
-			/delay 3 !${Me.AbilityReady[${pendingCast}]}
+		   |Slam is a special case and doesn't work with the normal /doability, this is a work around
+		   /if (${pendingCast.Equal[Slam]}) {
+
+				/if (${Window[ActionsAbilitiesPage].Child[AAP_FirstAbilityButton].Text.Equal[Slam]}) {
+					/doability 1
+				} else /if (${Window[ActionsAbilitiesPage].Child[AAP_SecondAbilityButton].Text.Equal[Slam]}) {
+					/doability 2
+				} else /if (${Window[ActionsAbilitiesPage].Child[AAP_ThirdAbilityButton].Text.Equal[Slam]}) {
+					/doability 3
+				} else /if (${Window[ActionsAbilitiesPage].Child[AAP_FourthAbilityButton].Text.Equal[Slam]}) {
+					/doability 4
+				} else /if (${Window[ActionsAbilitiesPage].Child[AAP_FifthAbilityButton].Text.Equal[Slam]}) {
+					/doability 5
+				} else /if (${Window[ActionsAbilitiesPage].Child[AAP_SixthAbilityButton].Text.Equal[Slam]}) {
+					/doability 6
+				}
+
+		   } else {
+		
+			   /doability "${pendingCast}"
+		
+		   }
+		   /delay 3 !${Me.AbilityReady[${pendingCast}]}
     	}
 	|-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	|- Spells, AA, Items

--- a/Macros/e3 Includes/e3_Casting.inc
+++ b/Macros/e3 Includes/e3_Casting.inc
@@ -393,11 +393,12 @@ Sub e3_Cast(int targetID, ArrayName, int ArrayIndex, bool StopEchos)
 					|call interrupt check
 					/call ${${ArrayName}[${ArrayIndex},${iSubToRun}]} ${ArrayName} ${ArrayIndex}
 
-					/if (!${c_SubToRun} && ${Me.Casting.ID}) {
+					/if (!${c_SubToRun}) {
            				/if (${Debug} || ${Debug_Casting}) /echo SubToRun called interrupt ${${ArrayName}[${ArrayIndex},${iSubToRun}]}
 					 	/call interrupt
 						/delay 3
-						/goto :interrupted
+						/varset castReturn CAST_INTERRUPTED
+						/goto :skipCast
 					}
 					  /delay 1
         		|-no SubToRun
@@ -409,11 +410,12 @@ Sub e3_Cast(int targetID, ArrayName, int ArrayIndex, bool StopEchos)
 
 				/doevents nowCast
 				|check to see if now Cast has decided to interrupt the casting.
-				/if (!${g_CastNowSpellCasting} && (!${c_SubToRun} && ${Me.Casting.ID})) {
+				/if (!${g_CastNowSpellCasting} && (!${c_SubToRun})) {
 							/if (${Debug} || ${Debug_Casting}) /echo nowCast called interrupt ${${ArrayName}[${ArrayIndex},${iSubToRun}]}
 							/call interrupt
 							/delay 1s
-							/goto :interrupted
+							/varset castReturn CAST_INTERRUPTED
+							/goto :skipCast
 				}
 
 				|- Other reasons to cancel
@@ -423,7 +425,8 @@ Sub e3_Cast(int targetID, ArrayName, int ArrayIndex, bool StopEchos)
 					/if (${Debug} || ${Debug_Casting}) /echo following interrupt
 					|/bc following interrupt ${Time}  ${NetBots[${FollowTarget}].Moving}  ${Spawn[${FollowTarget}].Moving} ${Spawn[${FollowTarget}].Distance}
 					/call interrupt
-					/goto :interrupted
+					/varset castReturn CAST_INTERRUPTED
+					/goto :skipCast
 					}
 				}
 				}
@@ -432,14 +435,16 @@ Sub e3_Cast(int targetID, ArrayName, int ArrayIndex, bool StopEchos)
 					
 					/if (${Debug} || ${Debug_Casting}) /echo duck called interrupt
 							/call interrupt
-							/goto :interrupted
+							/varset castReturn CAST_INTERRUPTED
+							/goto :skipCast
 				}
 						|-Dead target and I'm not using a detrimental AE or self buff
 				/if (!${Select[${${ArrayName}[${ArrayIndex},${iTargetType}]},PB AE,Targeted AE,Corpse,Self,Group v1]}) {
 					/if ((!${Bool[${Target.ID}]} || ${Spawn[${Target.ID}].Dead})) {
 						/if (${Debug} || ${Debug_Casting}) /echo target corpse called interrupt
 						/call interrupt
-						/goto :interrupted
+						/varset castReturn CAST_INTERRUPTED
+						/goto :skipCast
 					}
 				}
 						|-Target is out of range
@@ -447,7 +452,8 @@ Sub e3_Cast(int targetID, ArrayName, int ArrayIndex, bool StopEchos)
 					/if (${Target.Distance} > ${${ArrayName}[${ArrayIndex},${iMyRange}]}) {
 						/if (${Debug} || ${Debug_Casting}) /echo target range called interrupt
 						/call interrupt
-						/goto :interrupted
+						/varset castReturn CAST_INTERRUPTED
+						/goto :skipCast
 					}
 				}
 						|-Moved since casting began
@@ -456,7 +462,8 @@ Sub e3_Cast(int targetID, ArrayName, int ArrayIndex, bool StopEchos)
 					/if (${Math.Distance[${startingLoc}]}>=8) {
 						/if (${Debug} || ${Debug_Casting}) /echo moved 8+ units after casting: called interrupt
 						/call interrupt
-						/goto :interrupted
+						/varset castReturn CAST_INTERRUPTED
+						/goto :skipCast
 					}
 				}
 						|-Check LifeSupport if more than 1.5 sec left to cast end
@@ -494,9 +501,9 @@ Sub e3_Cast(int targetID, ArrayName, int ArrayIndex, bool StopEchos)
 			/varset immuneList ${immuneList}${pendingCastID}_${castTargetName},
     |dont create a nohold timer for detrimental AE spells
 		} else /if (${castReturn.Equal[CAST_TAKEHOLD]} && ${Select[${ArrayName},TargetAE_Spells2D,PBAE_Spells2D]}==0) {
-      /if (${Target.ID}==${targetID}) {
+     		 /if (${Target.ID}==${targetID}) {
 				/docommand ${ChatToggle} ** ${pendingCast} did not take hold on ${castTargetName} **
-        /call CreateTimer "nht${targetID}-${pendingCastID}" "${noHoldDelay}"
+       			/call CreateTimer "nht${targetID}-${pendingCastID}" "${noHoldDelay}"
 			}
 		} else /if (${Select[${castReturn},CAST_OUTDOORS,CAST_COMPONENTS,CAST_UNKNOWN]}) {
 			/docommand ** ${ChatToggle} Adding to failureList due to Return Events CAST_OUTDOORS,CAST_COMPONENT,CAST_UNKNOWN

--- a/Macros/e3 Includes/e3_Casting.inc
+++ b/Macros/e3 Includes/e3_Casting.inc
@@ -85,7 +85,7 @@ Sub e3_Cast(int targetID, ArrayName, int ArrayIndex, bool StopEchos)
     /if (${Me.Class.ShortName.Equal[Rog]}) {
       /if (!${Me.Combat} && ${SpawnCount[pc radius 40]} > 2 && !${SpawnCount[npc radius 100 zradius 100]} && ${idleTimer}<${Math.Calc[${idleInterval}*600 - 100]}) /makemevisible
     } else /if (!${${ArrayName}[${ArrayIndex},${iCastInvis}]}) {
-      /varset castReturn CAST_INVISIBLE
+      		/varset castReturn CAST_INVISIBLE
 			/echo SkipCast-Invis ${pendingCast} ${Spawn[id ${targetID}].Name} ${targetID}
 			/varset ActionTaken TRUE
       /goto :skipCast

--- a/Macros/e3 Includes/e3_Casting.inc
+++ b/Macros/e3 Includes/e3_Casting.inc
@@ -704,7 +704,7 @@ Sub casting_Setup
 	/varset vetArray[${iJester}]    "Chaotic Jester"
 	/call BuildSpellArray "vetArray" "vetArray2D"
 
-	/declare itemCooldownList[47,2] string local
+	/declare itemCooldownList[49,2] string local
 	/varset itemCooldownList[1,1] Summoned: Large Modulation Shard
 	/varset itemCooldownList[1,2] 300
 	/varset itemCooldownList[2,1] Shroud of the Subjugated Kuaan
@@ -799,10 +799,14 @@ Sub casting_Setup
 	/varset itemCooldownList[46,2] 480
 	/varset itemCooldownList[47,1] Prismatic Dragon Blade
 	/varset itemCooldownList[47,2] 300
+	/varset itemCooldownList[48,1] Staff of Phenomenal Power
+	/varset itemCooldownList[48,2] 180
+	/varset itemCooldownList[49,1] Academic's Robe of the Arcanists
+	/varset itemCooldownList[49,2] 300
 
   	|scan through each of the items in itemCooldownList to see if we actually have that item, if so put it in the lookup list.
 
-	/declare tempItemLookupList[47,2] string local
+	/declare tempItemLookupList[49,2] string local
 	/declare tempItemLookupListCounter int local 1
 
 	/declare index int local 1

--- a/Macros/e3 Includes/e3_Casting.inc
+++ b/Macros/e3 Includes/e3_Casting.inc
@@ -33,10 +33,9 @@ Sub e3_Cast(int targetID, ArrayName, int ArrayIndex, bool StopEchos)
 
 	/declare beforeSpell string local ${${ArrayName}[${ArrayIndex},${iBeforeSpell}]}
 	/if (${beforeSpell.Length}>1) {
-		/if (${Me.SpellReady[${beforeSpell}]} || ${Me.AltAbilityReady[${beforeSpell}]} || ${Me.ItemReady[${beforeSpell}]} ) {
-			/call castSimpleSpell "${beforeSpell}" 0
-		}
+		/call CastAfterBeforeSpell "${beforeSpell}"
 	}
+
 	/declare afterSpell string local ${${ArrayName}[${ArrayIndex},${iAfterSpell}]}
 	/varset pendingCast	${${ArrayName}[${ArrayIndex},${iCastName}]}
 	/varset pendingCastID ${${ArrayName}[${ArrayIndex},${iCastID}]}
@@ -466,15 +465,46 @@ Sub e3_Cast(int targetID, ArrayName, int ArrayIndex, bool StopEchos)
 			|on the next event cycle as event cycles in e3 are far faster than the server can send us
 			|the cooldown information
 			|/echo e3_Cast: Setting spell recast timer of 2 seconds
-			/call CreateTimer "SpellRecast_${pendingCastID}" "2s"
+			/call casting_ItemCooldown "${pendingCast}"
+			/declare itemRecastToUseInSeconds int ${Macro.Return}
+
+			/if (${itemRecastToUseInSeconds}<60) {
+				|/varset itemRecastToUseInSeconds ${Math.Calc[${itemRecastToUseInSeconds}]}
+			} else {
+				/varcalc itemRecastToUseInSeconds ${Math.Calc[${itemRecastToUseInSeconds}+6]}
+			}
+			/call CreateTimer "SpellRecast_${pendingCastID}" "${itemRecastToUseInSeconds}s"
 	}
 
 	/if (${afterSpell.Length}>1) {
-		/if (${Me.SpellReady[${afterSpell}]} || ${Me.AltAbilityReady[${afterSpell}]} || ${Me.ItemReady[${afterSpell}]} ) {
-			/call castSimpleSpell "${afterSpell}" 0
+		/call CastAfterBeforeSpell "${afterSpell}"
+	}
+
+|/varset Debug_Casting FALSE
+/return
+
+
+sub CastAfterBeforeSpell(spellName)
+	
+	/if (${spellName.Length}>1) {
+		/declare spellItemReady bool local ${Me.ItemReady[${spellName}]}
+		/if (${Me.SpellReady[${spellName}]} || ${Me.AltAbilityReady[${spellName}]} || ${spellItemReady} ) {
+			/if (${spellItemReady}) {
+				|need to check if there is a cooldown on it
+				/declare spellItemID int local ${FindItem[${spellName}].ID}
+				/if (${Defined[SpellRecast_${spellItemID}]}) {
+							
+					/if (${SpellRecast_${spellItemID}}) {
+						|our timer is still active, skip this and say we are not recovered yet.
+						|No action taken, so they can cast the next thing in the list.
+						|/echo CastAfterBeforeSpell SpellRecast is on cooldown still for: ${SpellRecast_${spellItemID}} seconds
+						/return
+					}
+				} 
+			}
+			/call castSimpleSpell "${spellName}" 0
 		}
 	}
-|/varset Debug_Casting FALSE
 /return
 
 |------------------------------------------------|
@@ -488,7 +518,23 @@ Sub check_Ready(ArrayName, int ArrayIndex)
     /if (!${Bool[${Me.Gem[${${ArrayName}[${ArrayIndex},${iCastName}]}]}]}) /call memorize_spell "${${ArrayName}[${ArrayIndex},${iCastName}]}" ${${ArrayName}[${ArrayIndex},${iSpellGem}]}
     /if (${Me.SpellReady[${${ArrayName}[${ArrayIndex},${iCastName}]}]}) /varset c_Ready TRUE
   } else /if (${${ArrayName}[${ArrayIndex},${iCastType}].Equal[Item]}) {
-    /if (${Me.ItemReady[=${${ArrayName}[${ArrayIndex},${iCastName}]}]}) /varset c_Ready TRUE
+	|Need to check if we already have this item on cooldown
+	/declare itemID int local ${FindItem[=${${ArrayName}[${ArrayIndex},${iCastName}]}].ID}
+	/if (${Defined[SpellRecast_${itemID}]}) {
+				
+		/if (${SpellRecast_${itemID}}) {
+			|our timer is still active, skip this and say we are not recovered yet.
+			|No action taken, so they can cast the next thing in the list.
+			|/echo check_Ready SpellRecast is on cooldown still for: ${SpellRecast_${itemID}}
+			/varset c_Ready FALSE
+			/goto :endOfCheckReady
+
+		}
+	} 
+	/if (${Me.ItemReady[=${${ArrayName}[${ArrayIndex},${iCastName}]}]}) {
+		/varset c_Ready TRUE
+	} 
+  
   } else /if (${${ArrayName}[${ArrayIndex},${iCastType}].Equal[AA]}) {
     /if (${Me.AltAbilityReady[${${ArrayName}[${ArrayIndex},${iCastName}]}]})  /varset c_Ready TRUE
   } else /if (${${ArrayName}[${ArrayIndex},${iCastType}].Equal[Disc]}) {
@@ -497,7 +543,11 @@ Sub check_Ready(ArrayName, int ArrayIndex)
     /if (${Me.AbilityReady[${${ArrayName}[${ArrayIndex},${iCastName}]}]}) /varset c_Ready TRUE
   }
 
+
+	:endOfCheckReady
+
   /if (${Debug} || ${Debug_Casting}) /echo |- check_Ready <= ${c_Ready}
+
 /RETURN ${c_Ready}
 
 Sub memorize_spell(spellName,gemNum)
@@ -614,40 +664,183 @@ Sub casting_Setup
 	/declare castEndTime				timer outer
 	/declare noInvis						bool outer TRUE
 	/declare noFeigning					bool outer TRUE
-  /declare interruptFlag			bool outer FALSE
-	
+	/declare interruptFlag			bool outer FALSE
+
 	/declare failureList			string outer
 	/declare immuneList				string outer
 
-  /declare c_Ready bool outer FALSE
-  /declare c_SubToRun bool outer FALSE
+	/declare c_Ready bool outer FALSE
+	/declare c_SubToRun bool outer FALSE
 
 	/declare DefaultGem int outer 8
 	/call iniToVarV "${genSettings_Ini},Casting,Default Spell Gem" DefaultGem int outer
-  /call iniToVarV "${genSettings_Ini},Casting,Default Spell Set" Default_SpellSet string outer
+	/call iniToVarV "${genSettings_Ini},Casting,Default Spell Set" Default_SpellSet string outer
 
-  /declare vetArray[8] string outer
-  /declare iLesson    int outer 1
-  |/declare iThrone    int outer 2
-  /declare iArmor     int outer 2
-  /declare iIntensity int outer 3
-  /declare iImfusion  int outer 4
-  /declare iSteadfast int outer 5
-  /declare iStaunch   int outer 6
-  /declare iExpedient int outer 7
-  /declare iJester    int outer 8
-  /varset vetArray[${iLesson}]    "Lesson of the Devoted"
-  |/varset vetArray[${iThrone}]    "Throne of Heroes"
-  /varset vetArray[${iArmor}]     "Armor of Experience"
-  /varset vetArray[${iIntensity}] "Intensity of the Resolute"
-  /varset vetArray[${iImfusion}]  "Infusion of the Faithful"
-  /varset vetArray[${iSteadfast}] "Steadfast Servant"
-  /varset vetArray[${iStaunch}]   "Staunch Recovery"
-  /varset vetArray[${iExpedient}] "Expedient Recovery"
-  /varset vetArray[${iJester}]    "Chaotic Jester"
-  /call BuildSpellArray "vetArray" "vetArray2D"
+	/declare vetArray[8] string outer
+	/declare iLesson    int outer 1
+	|/declare iThrone    int outer 2
+	/declare iArmor     int outer 2
+	/declare iIntensity int outer 3
+	/declare iImfusion  int outer 4
+	/declare iSteadfast int outer 5
+	/declare iStaunch   int outer 6
+	/declare iExpedient int outer 7
+	/declare iJester    int outer 8
+	/varset vetArray[${iLesson}]    "Lesson of the Devoted"
+	|/varset vetArray[${iThrone}]    "Throne of Heroes"
+	/varset vetArray[${iArmor}]     "Armor of Experience"
+	/varset vetArray[${iIntensity}] "Intensity of the Resolute"
+	/varset vetArray[${iImfusion}]  "Infusion of the Faithful"
+	/varset vetArray[${iSteadfast}] "Steadfast Servant"
+	/varset vetArray[${iStaunch}]   "Staunch Recovery"
+	/varset vetArray[${iExpedient}] "Expedient Recovery"
+	/varset vetArray[${iJester}]    "Chaotic Jester"
+	/call BuildSpellArray "vetArray" "vetArray2D"
+
+	/declare itemCooldownList[47,2] string local
+	/varset itemCooldownList[1,1] Summoned: Large Modulation Shard
+	/varset itemCooldownList[1,2] 300
+	/varset itemCooldownList[2,1] Shroud of the Subjugated Kuaan
+	/varset itemCooldownList[2,2] 3600
+	/varset itemCooldownList[3,1] Orb of Shadows
+	/varset itemCooldownList[3,2] 30
+	/varset itemCooldownList[4,1] Graverobber's Icon
+	/varset itemCooldownList[4,2] 600
+	/varset itemCooldownList[5,1] Aged Shissar Apothic Staff
+	/varset itemCooldownList[5,2] 0
+	/varset itemCooldownList[6,1] Weighted Hammer of Conviction
+	/varset itemCooldownList[6,2] 0
+	/varset itemCooldownList[7,1] Molten Orb
+	/varset itemCooldownList[7,2] 12
+	/varset itemCooldownList[8,1] Innoruuk's Dark Blassing
+	/varset itemCooldownList[8,2] 300
+	/varset itemCooldownList[9,1] Blood Drinker's Coating
+	/varset itemCooldownList[9,2] 600
+	/varset itemCooldownList[10,1] Blightbringer's Tunic of the Grave
+	/varset itemCooldownList[10,2] 300
+	/varset itemCooldownList[11,1] Dagger of Death
+	/varset itemCooldownList[11,2] 120
+	/varset itemCooldownList[12,1] Duskbringer's Plate Chestguard of the Hateful
+	/varset itemCooldownList[12,2] 300
+	/varset itemCooldownList[13,1] Minion's Memento
+	/varset itemCooldownList[13,2] 600
+	/varset itemCooldownList[14,1] Blessed Spiritstaff of the Heyokah
+	/varset itemCooldownList[14,2] 180
+	/varset itemCooldownList[15,1] Mindreaver's Vest  of Coercion
+	/varset itemCooldownList[15,2] 30
+	/varset itemCooldownList[16,1] Staff of Eternal Eloquence
+	/varset itemCooldownList[16,2] 90
+	/varset itemCooldownList[17,1] Aged Hammer of the Dragonborn
+	/varset itemCooldownList[17,2] 210
+	/varset itemCooldownList[18,1] Azure Mind Crystal
+	/varset itemCooldownList[18,2] 180
+	/varset itemCooldownList[19,1] Zun'Muram's Spear of Doom
+	/varset itemCooldownList[19,2] 210
+	/varset itemCooldownList[20,1] Ritualchanter's Tunic of the Ancestors
+	/varset itemCooldownList[20,2] 300
+	/varset itemCooldownList[21,1] Hammer of Delusions
+	/varset itemCooldownList[21,2] 120
+	/varset itemCooldownList[22,1] Bladewhisper Chain Vest of Journeys
+	/varset itemCooldownList[22,2] 300
+	/varset itemCooldownList[23,1] Aurora, the Heartwood Bow
+	/varset itemCooldownList[23,2] 180
+	/varset itemCooldownList[24,1] Faithbringer's Breastplate of Conviction
+	/varset itemCooldownList[24,2] 300
+	/varset itemCooldownList[25,1] Aegis of Superior Divinity
+	/varset itemCooldownList[25,2] 120
+	/varset itemCooldownList[26,1] Glyphwielder's Tunic of the Summoner
+	/varset itemCooldownList[26,2] 300
+	/varset itemCooldownList[27,1] Vengeful Taelosian Blood Axe
+	/varset itemCooldownList[27,2] 180
+	/varset itemCooldownList[28,1] Focus of Primal Elements
+	/varset itemCooldownList[28,2] 180
+	/varset itemCooldownList[29,1] Wrathbringer's Chain Chestguard of the Vindicator
+	/varset itemCooldownList[29,2] 300
+	/varset itemCooldownList[30,1] Dagger of Evil Summons
+	/varset itemCooldownList[30,2] 120
+	/varset itemCooldownList[31,1] Aged Sarnak Channeler Staff
+	/varset itemCooldownList[31,2] 120
+	/varset itemCooldownList[32,1] Blade of Vesagran
+	/varset itemCooldownList[32,2] 180
+	/varset itemCooldownList[33,1] Kept-Covered Hammer
+	/varset itemCooldownList[33,2] 210
+	/varset itemCooldownList[34,1] Farseeker's Plate Chestguard of Harmony
+	/varset itemCooldownList[34,2] 300
+	/varset itemCooldownList[35,1] Everspring Jerkin of the Tangled Briars
+	/varset itemCooldownList[35,2] 300
+	/varset itemCooldownList[36,1] Master Lazarus Charm
+	/varset itemCooldownList[36,2] 450
+	/varset itemCooldownList[37,1] Staff of Everliving Brambles
+	/varset itemCooldownList[37,2] 180
+	/varset itemCooldownList[38,1] Gladiator's Plate Chestguard of War
+	/varset itemCooldownList[38,2] 300
+	/varset itemCooldownList[39,1] Kreljnok's Sword of Eternal Power
+	/varset itemCooldownList[39,2] 60
+	/varset itemCooldownList[40,1] Blood Drinker's Coating
+	/varset itemCooldownList[40,2] 600
+	/varset itemCooldownList[41,1] Bottomless Venom Vial
+	/varset itemCooldownList[41,2] 180
+	/varset itemCooldownList[42,1] Grobb Frenzy Maxx
+	/varset itemCooldownList[42,2] 120
+	/varset itemCooldownList[43,1] Fabled Idol of the Underking
+	/varset itemCooldownList[43,2] 2
+	/varset itemCooldownList[44,1] Fabled Idol of the UnderkingShattered Gnoll Slayer
+	/varset itemCooldownList[44,2] 600
+	/varset itemCooldownList[45,1] Rapier of Somber Notes
+	/varset itemCooldownList[45,2] 120
+	/varset itemCooldownList[46,1] Innoruuk's Voice
+	/varset itemCooldownList[46,2] 480
+	/varset itemCooldownList[47,1] Prismatic Dragon Blade
+	/varset itemCooldownList[47,2] 300
+
+  	|scan through each of the items in itemCooldownList to see if we actually have that item, if so put it in the lookup list.
+
+	/declare tempItemLookupList[47,2] string local
+	/declare tempItemLookupListCounter int local 1
+
+	/declare index int local 1
+	/for index 1 to ${itemCooldownList.Size[1]} 
+		/if (${Bool[${FindItem[${itemCooldownList[${index},1]}]}]}) {
+			|found the item, add the name/index in the primary list to the temp list.
+			/varset tempItemLookupList[${tempItemLookupListCounter},1]  ${itemCooldownList[${index},1]}
+			/varset tempItemLookupList[${tempItemLookupListCounter},2]  ${itemCooldownList[${index},2]}
+			/varcalc tempItemLookupListCounter ${tempItemLookupListCounter}+1
+		}
+	/next index
+
+	|creating our final list of only the size we need
+	/declare itemCooldownLookupList[${Math.Calc[${tempItemLookupListCounter}-1]},2] string outer
+	
+	/for index 1 to ${itemCooldownLookupList.Size[1]} 
+			|found the item, add the name/index in the primary list to the temp list.
+			/varset itemCooldownLookupList[${index},1]  ${tempItemLookupList[${index},1]}
+			/varset itemCooldownLookupList[${index},2]  ${tempItemLookupList[${index},2]}
+	/next index
+
+	
+	/for index 1 to ${itemCooldownLookupList.Size[1]}
+
+		/echo ${index} ) ${itemCooldownLookupList[${index},1]}
+
+	/next index
+
+
 /if (${Debug} || ${Debug_Casting}) /echo <== casting_Setup -|
 /return
+
+
+sub casting_ItemCooldown(itemName)
+
+	/declare returnValue int local 2
+	/declare i int local 0
+	/for i 1 to ${itemCooldownLookupList.Size[1]}
+
+			/if (${itemCooldownLookupList[${i},1].Equal[${itemName}]}) {
+				/varset returnValue ${itemCooldownLookupList[${i},2]}
+				/break
+			}
+	/next i
+/return ${returnValue}
 
 |~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Sub casting_Background_Events
@@ -692,4 +885,28 @@ SUB check_SpellGemLockup
 			/bc ${Me.CleanName}'s spell gems are locked! ${UnlockSpell} is not up!
 		}
 	}
+/return
+|--------------------------------------------------------------------------------------------|
+|- Used to call the e3_Cast for simple spells that cannot normally fail.                   	-|
+|--------------------------------------------------------------------------------------------|
+sub castSimpleSpell(spellNameToBase, simpleTargetIDToBase)
+
+    /call castSimpleSpellBase "${spellNameToBase}" ${simpleTargetIDToBase} True
+
+/return
+sub castSimpleSpellBase(spellName, simpleTargetID, SkipParams)
+
+  /if (${simpleTargetID}==0) {
+    |if 0 passed in, set it to whatever they are targeting
+    /varset simpleTargetID ${Target.ID}
+  }
+    |/echo building the spell array for heirlooms
+  /call BuildSingleSpellArrayBase "${spellName}" "castSimpleSpellArray2D" ${SkipParams}
+   
+    /call e3_Cast ${simpleTargetID} "castSimpleSpellArray2D" 1 False
+    /while (${Select[${castReturn},CAST_FIZZLE]}) {
+          /delay 1s
+          /call e3_Cast  ${simpleTargetID} "castSimpleSpellArray2D" 1 False
+    }
+
 /return

--- a/Macros/e3 Includes/e3_Casting.inc
+++ b/Macros/e3 Includes/e3_Casting.inc
@@ -1058,12 +1058,11 @@ sub castSimpleSpellBase(spellName, simpleTargetID, SkipParams)
 	/call check_Ready "castSimpleSpellArray2D" 1
 	/declare checkReadyCounter int local 0
     /while (!${c_Ready}) {
-		/echo castSimpleSpellBase:check_Ready: not ready, waiting: ${spellName}
+		
 		/delay 3
 		/call check_Ready "castSimpleSpellArray2D" 1		
 		/varcalc checkReadyCounter ${checkReadyCounter} +1
 		/if (${checkReadyCounter} > 6) {
-			/echo castSimpleSpellBase:check_Ready: failing after 6 attempts, kicking out. Things may break. 
 			/return
 		}
 	}

--- a/Macros/e3 Includes/e3_Casting.inc
+++ b/Macros/e3 Includes/e3_Casting.inc
@@ -184,7 +184,7 @@ Sub e3_Cast(int targetID, ArrayName, int ArrayIndex, bool StopEchos)
 				/delay 5 ${Target.ID} == ${targetID}
 			}
 			/varset ActionTaken TRUE
-			/disc "${pendingCast}"
+			/disc ${pendingCast}
 			/delay 3
 		}
 	|-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/Macros/e3 Includes/e3_Casting.inc
+++ b/Macros/e3 Includes/e3_Casting.inc
@@ -612,6 +612,65 @@ Sub check_Ready(ArrayName, int ArrayIndex)
 
 /RETURN ${c_Ready}
 
+
+Sub check_ReadySimple(spellName, gemToUse)
+  /if (${Debug} || ${Debug_Casting}) /echo |- check_ReadySimple =>
+  /varset c_Ready FALSE
+  | Memorize the spell if it is not memorized
+  
+	/declare spellType string local 
+
+	/if (${Bool[${Me.AltAbility[${spellName}].Spell}]}) {
+		/varset spellType AA
+	} else /if (${Me.Book[${spellName}]}) {
+		/varset spellType Spell
+	} else /if (${Me.CombatAbility[${spellName}]}) {
+		/varset spellType Disc
+	} else /if (${Me.Ability[${spellName}]}) {
+		/varset spellType Ability			
+	} else {
+		/varset spellType Item
+	}
+  /if (${spellType.Equal[Spell]}) {
+    /if (!${Bool[${Me.Gem[${spellName}]}]}) {
+		/declare tempGemNum int local ${DefaultGem}
+		/if (${Bool[gemTouse]}) {
+			/varset tempGemNum ${gemToUse}
+		}
+		/call memorize_spell "${spellName}" ${tempGemNum}
+	}
+	/if (${Me.SpellReady[${spellName}]}) /varset c_Ready TRUE
+  } else /if (${spellType.Equal[Item]}) {
+	|Need to check if we already have this item on cooldown
+	/declare itemID int local ${FindItem[=${spellName}].ID}
+	/if (${Defined[SpellRecast_${itemID}]}) {
+				
+		/if (${SpellRecast_${itemID}}) {
+			|our timer is still active, skip this and say we are not recovered yet.
+			|No action taken, so they can cast the next thing in the list.
+			|/echo check_Ready SpellRecast is on cooldown still for: ${SpellRecast_${itemID}}
+			/varset c_Ready FALSE
+			/goto :check_ReadySimple
+
+		}
+	} 
+	/if (${Me.ItemReady[=${spellName}]}) {
+		/varset c_Ready TRUE
+	} 
+  
+  } else /if (${spellType.Equal[AA]}) {
+    /if (${Me.AltAbilityReady[${spellName}]})  /varset c_Ready TRUE
+  } else /if (${spellType.Equal[Disc]}) {
+    /if (${Me.CombatAbilityReady[${spellName}]}) /varset c_Ready TRUE
+  } else /if (${spellType.Equal[Ability]}) {
+    /if (${Me.AbilityReady[${spellName}]}) /varset c_Ready TRUE
+  }
+   :check_ReadySimple
+
+  /if (${Debug} || ${Debug_Casting}) /echo |- check_ReadySimple <= ${c_Ready}
+
+/RETURN ${c_Ready}
+
 Sub memorize_spell(spellName,gemNum)
   /if (${Debug} || ${Debug_Casting}) /echo |- memorize_spell =>
   	/memorize "${spellName}" ${gemNum}
@@ -887,6 +946,7 @@ Sub casting_Setup
 	/declare tempItemLookupList[57,2] string local
 	/declare tempItemLookupListCounter int local 1
 
+
 	/declare index int local 1
 	/for index 1 to ${itemCooldownList.Size[1]} 
 		/if (${Bool[${FindItem[${itemCooldownList[${index},1]}]}]}) {
@@ -896,23 +956,26 @@ Sub casting_Setup
 			/varcalc tempItemLookupListCounter ${tempItemLookupListCounter}+1
 		}
 	/next index
-
 	|creating our final list of only the size we need
 	/declare itemCooldownLookupList[${Math.Calc[${tempItemLookupListCounter}-1]},2] string outer
 	
-	/for index 1 to ${itemCooldownLookupList.Size[1]} 
-			|found the item, add the name/index in the primary list to the temp list.
-			/varset itemCooldownLookupList[${index},1]  ${tempItemLookupList[${index},1]}
-			/varset itemCooldownLookupList[${index},2]  ${tempItemLookupList[${index},2]}
-	/next index
+	/if (${itemCooldownLookupList.Size[1]}>1) {
 
-	/echo Items to keep timers on.
-	/for index 1 to ${itemCooldownLookupList.Size[1]}
+		/for index 1 to ${itemCooldownLookupList.Size[1]} 
+				|found the item, add the name/index in the primary list to the temp list.
+				/varset itemCooldownLookupList[${index},1]  ${tempItemLookupList[${index},1]}
+				/varset itemCooldownLookupList[${index},2]  ${tempItemLookupList[${index},2]}
+		/next index
 
-		/echo ${index} ) ${itemCooldownLookupList[${index},1]}
+		/echo Items to keep timers on.
+		/for index 1 to ${itemCooldownLookupList.Size[1]}
 
-	/next index
+			/echo ${index} ) ${itemCooldownLookupList[${index},1]}
 
+		/next index
+
+	}
+	
 
 /if (${Debug} || ${Debug_Casting}) /echo <== casting_Setup -|
 /return

--- a/Macros/e3 Includes/e3_Casting.inc
+++ b/Macros/e3 Includes/e3_Casting.inc
@@ -29,16 +29,17 @@
 Sub e3_Cast(int targetID, ArrayName, int ArrayIndex, bool StopEchos)
 |StopEchos = Skips the /echo on successful cast if a value other than 0 is passed with the /call e3_Cast
 /if (${Debug} || ${Debug_Casting}) /echo |- e3_Cast ==>
-	/varset pendingCast		${${ArrayName}[${ArrayIndex},${iCastName}]}
-	/varset pendingCastID	${${ArrayName}[${ArrayIndex},${iCastID}]}
+	/varset pendingCast	${${ArrayName}[${ArrayIndex},${iCastName}]}
+	/varset pendingCastID ${${ArrayName}[${ArrayIndex},${iCastID}]}
 	/declare castTargetName string local ${Spawn[id ${targetID}].CleanName}
 	/declare e3_CastTime int local ${${ArrayName}[${ArrayIndex},${iMyCastTime}]}
-	/varset castEndTime		0
-  /varset castReturn		0
+	/varset castEndTime	0
+	/varset castReturn 0
 	/varset interruptFlag FALSE
-	/declare pendingType	string local
-  /declare oldItem			string local
-	/declare i						int local
+	/declare pendingType string local
+	/declare oldItem string local
+	/declare i	int local
+	/varset	returnTwist FALSE
 	|this needs to be set to true every run, as its checked for interrupt method calls. Technically they set it to true every time they run, but best to 
 	|be sure this is reset.
 	/varset c_SubToRun TRUE
@@ -48,18 +49,59 @@ Sub e3_Cast(int targetID, ArrayName, int ArrayIndex, bool StopEchos)
   |if im invis and iCastInvis=0 (default except for heals)
   |if im a rog, not in combat, done no action for 10+ seconds, and near 2+ other players then drop invis to buff (allows autohide)
   
-  /if (!${Twist.Twisting} && ${Me.Class.ShortName.Equal[BRD]} && ${Bool[${Me.Casting.ID}]} && !${${ArrayName}[${ArrayIndex},${iCastType}].Equal[Ability]} && !${${ArrayName}[${ArrayIndex},${iCastType}].Equal[Disc]} ) {
-    |turn off our current song so that items and other things can be clicked
-	 /if (${Bool[${Me.Gem[${Me.Casting}]}]}) {
-		 /echo doing a spell click off
- 		/cast ${Me.Gem[${Me.Casting}]}
-	} else {
-		|an item cast most likely, we have to click some valid gem
-		/echo doing an item click off
-		/cast 1
+  |if we are a bard, and not doing async twisting this section of code
+  |will 'block' as the check_BardSongs does not block on its call.
+  |this allows other check_ Methods to run to do their computation while the spell is running
+  |if they have to do an e3_Cast for their stuff, they will block here until the song is complete
+  |if they don't do anything, it ends up blocking back in check_BardSongs for the next song on the list. 
+  /if (!${Twist.Twisting} && ${Me.Class.ShortName.Equal[BRD]}) {
+	   	/if (!${playingMelody}) {
+      		/echo issuing stopcast and kicking out
+      		/stopcast
+      		/goto :endBardSongLock
+    	}	 
+	   /while (${Window[CastingWindow].Open}) {
+		/doevents Follow
+		/if (!${Window[CastingWindow].Open}) {
+		/break
+		}
+		/doevents Stop
+		/if (!${Window[CastingWindow].Open}) {
+		/break
+		}
+		/doevents MoveHere
+		/if (!${Window[CastingWindow].Open}) {
+		/break
+		}
+		/doevents BackOff
+		/if (!${Window[CastingWindow].Open}) {
+		/break
+		}
+		/doevents clickit
+		/if (!${Window[CastingWindow].Open}) {
+		/break
+		}
+		/doevents bark
+		/if (!${Window[CastingWindow].Open}) {
+		/break
+		}
+		/call alerts_Background_Events
+		/if (!${Window[CastingWindow].Open}) {
+		/break
+		}
+		/delay 1
 	}
+
+   }
+:endBardSongLock
+  |if we are not using MQ2Twist, but we currently have a cast going yet no cast window, issue a stopcast
+  /if (!${Twist.Twisting} && ${Me.Class.ShortName.Equal[BRD]} && ${Bool[${Me.Casting.ID}]} && !${${ArrayName}[${ArrayIndex},${iCastType}].Equal[Ability]} && !${${ArrayName}[${ArrayIndex},${iCastType}].Equal[Disc]} ) {
+    |sometimes when the window is gone but the buff hasn't quite landed yet, stopcast can cancel it. delay 1 to make sure that situation is avoided
+	/delay 1
+	/stopcast
   }
-  
+   
+
   |CatchAll Function for potentially locked up spell gems.
   /if (!${Select[${Me.Class.ShortName},WAR,ROG,MNK,BER]}) {
   	/call check_SpellGemLockup
@@ -197,6 +239,7 @@ Sub e3_Cast(int targetID, ArrayName, int ArrayIndex, bool StopEchos)
 		/if (${Select[${Me.Class.ShortName},BRD]} && ${e3_CastTime} >0) {
 			/if (${Twist.Twisting}) {
 				|this sets returnTwist to true
+				/varset	returnTwist TRUE
 				/call pauseTwist
 				/delay 3s !${Me.Casting.ID}
 				/delay 3
@@ -298,7 +341,7 @@ Sub e3_Cast(int targetID, ArrayName, int ArrayIndex, bool StopEchos)
 		/varcalc castEndTime ${Me.Casting.MyCastTime}/100
 :cast_still_pending
 |- check for reasons to cancel casting
-		/if (${Cast.Status.Find[C]}) {
+		/if (${Cast.Status.Find[C]} || ${Window[CastingWindow].Open}) {
 		  |dont allow item swap/must equip interrupts to avoid crashes
 
 
@@ -428,7 +471,10 @@ Sub e3_Cast(int targetID, ArrayName, int ArrayIndex, bool StopEchos)
 	/if (${Following} && !${Assisting}) /call AcquireFollow
   	/if (${Me.Class.ShortName.Equal[BRD]}) /varset resumeTwistDelay 5
  	|if the twist was stopped for this.
-	/if (${returnTwist})	/call unpauseTwist
+	/if (${returnTwist}) {
+		/call unpauseTwist
+		/varset	returnTwist FALSE
+	}	
   	/if (${Debug} || ${Debug_Casting})  /echo |- e3_Cast -| castReturn= ${Cast.Result} ${castReturn}
 
 

--- a/Macros/e3 Includes/e3_Casting.inc
+++ b/Macros/e3 Includes/e3_Casting.inc
@@ -790,7 +790,7 @@ Sub casting_Setup
 	/varset itemCooldownList[42,1] Grobb Frenzy Maxx
 	/varset itemCooldownList[42,2] 120
 	/varset itemCooldownList[43,1] Fabled Idol of the Underking
-	/varset itemCooldownList[43,2] 2
+	/varset itemCooldownList[43,2] 22
 	/varset itemCooldownList[44,1] Fabled Idol of the UnderkingShattered Gnoll Slayer
 	/varset itemCooldownList[44,2] 600
 	/varset itemCooldownList[45,1] Rapier of Somber Notes

--- a/Macros/e3 Includes/e3_Casting.inc
+++ b/Macros/e3 Includes/e3_Casting.inc
@@ -272,7 +272,7 @@ Sub e3_Cast(int targetID, ArrayName, int ArrayIndex, bool StopEchos)
 			/if (${pendingType.Equal[Item]}) {
 				/delay 3
 			}**|		
-			/if (${Bool[${FindItem[=${pendingCast}]}]}) {
+			/if (${pendingType.Equal[Item]}) {
 
 				/useitem "${pendingCast}"
 				|set to a default good value unless overwritten for a reason
@@ -293,7 +293,7 @@ Sub e3_Cast(int targetID, ArrayName, int ArrayIndex, bool StopEchos)
 				/delay 3
 			}	
 			**|			
-			/if (${Bool[${FindItem[=${pendingCast}]}]}) {
+			/if (${pendingType.Equal[Item]}) {
 				/declare i_target int local 0
 				|/echo getting tareget for item
 				/for i 1 to 5
@@ -325,7 +325,7 @@ Sub e3_Cast(int targetID, ArrayName, int ArrayIndex, bool StopEchos)
 		/varcalc castEndTime ${Me.Casting.MyCastTime}/100
 :cast_still_pending
 |- check for reasons to cancel casting
-		/if (${Cast.Status.Find[C]} || ${Window[CastingWindow].Open}) {
+		/if (${Window[CastingWindow].Open}) {
 		  |dont allow item swap/must equip interrupts to avoid crashes
 
 		   	/if (${Me.Class.ShortName.Equal[BRD]}) {

--- a/Macros/e3 Includes/e3_Casting.inc
+++ b/Macros/e3 Includes/e3_Casting.inc
@@ -284,7 +284,8 @@ Sub e3_Cast(int targetID, ArrayName, int ArrayIndex, bool StopEchos)
 				
 
 			} else {
-				/casting "${pendingCastID}|${pendingType}"		
+				/casting "${pendingCastID}|${pendingType}"
+				/delay 3		
 			}
 
 		} else {
@@ -317,6 +318,7 @@ Sub e3_Cast(int targetID, ArrayName, int ArrayIndex, bool StopEchos)
 				
 			} else {
 				/casting "${pendingCastID}|${pendingType}" "-targetid|${targetID}"
+				/delay 3
 			}
 		}
 		|- Memorizing spell

--- a/Macros/e3 Includes/e3_Casting.inc
+++ b/Macros/e3 Includes/e3_Casting.inc
@@ -268,11 +268,11 @@ Sub e3_Cast(int targetID, ArrayName, int ArrayIndex, bool StopEchos)
 		}
 		
 		/if (${${ArrayName}[${ArrayIndex},${iTargetType}].Equal[Self]}) {
-			/casting "${pendingCast}|${pendingType}"
+			|**/casting "${pendingCast}|${pendingType}"
 			/if (${pendingType.Equal[Item]}) {
 				/delay 3
-			}		
-			|**/if (${Bool[${FindItem[=${pendingCast}]}]}) {
+			}**|		
+			/if (${Bool[${FindItem[=${pendingCast}]}]}) {
 
 				/useitem "${pendingCast}"
 				|set to a default good value unless overwritten for a reason
@@ -285,14 +285,14 @@ Sub e3_Cast(int targetID, ArrayName, int ArrayIndex, bool StopEchos)
 
 			} else {
 				/casting "${pendingCastID}|${pendingType}"		
-			}**|
+			}
 
 		} else {
-			/casting "${pendingCast}|${pendingType}" "-targetid|${targetID}"
+			|**/casting "${pendingCast}|${pendingType}" "-targetid|${targetID}"
 			/if (${pendingType.Equal[Item]}) {
 				/delay 3
 			}	
-			|**			
+			**|			
 			/if (${Bool[${FindItem[=${pendingCast}]}]}) {
 				/declare i_target int local 0
 				|/echo getting tareget for item
@@ -317,7 +317,7 @@ Sub e3_Cast(int targetID, ArrayName, int ArrayIndex, bool StopEchos)
 				
 			} else {
 				/casting "${pendingCastID}|${pendingType}" "-targetid|${targetID}"
-			}**|
+			}
 		}
 		|- Memorizing spell
 		/if (${Cast.Status.Find[M]}) /delay 3s !${Cast.Status.Find[M]}

--- a/Macros/e3 Includes/e3_Casting.inc
+++ b/Macros/e3 Includes/e3_Casting.inc
@@ -183,7 +183,7 @@ Sub e3_Cast(int targetID, ArrayName, int ArrayIndex, bool StopEchos)
 			}
 			/varset ActionTaken TRUE
 			/disc ${pendingCast}
-			/delay 3
+			/delay 5 !${Me.CombatAbilityReady[${pendingCast}]}
 		}
 	|-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	|- Abilities

--- a/Macros/e3 Includes/e3_Casting.inc
+++ b/Macros/e3 Includes/e3_Casting.inc
@@ -39,7 +39,7 @@ Sub e3_Cast(int targetID, ArrayName, int ArrayIndex, bool StopEchos)
 	/declare pendingType string local
 	/declare oldItem string local
 	/declare i	int local
-	/varset	returnTwist FALSE
+	/declare reEnableTwist bool local FALSE
 	|this needs to be set to true every run, as its checked for interrupt method calls. Technically they set it to true every time they run, but best to 
 	|be sure this is reset.
 	/varset c_SubToRun TRUE
@@ -203,7 +203,7 @@ Sub e3_Cast(int targetID, ArrayName, int ArrayIndex, bool StopEchos)
 		/if (${Select[${Me.Class.ShortName},BRD]} && ${e3_CastTime} >0) {
 			/if (${Twist.Twisting}) {
 				|this sets returnTwist to true
-				/varset	returnTwist TRUE
+				/varset	reEnableTwist TRUE
 				/call pauseTwist
 				/delay 3s !${Me.Casting.ID}
 				/delay 3
@@ -439,7 +439,7 @@ Sub e3_Cast(int targetID, ArrayName, int ArrayIndex, bool StopEchos)
  	|if the twist was stopped for this.
 	/if (${returnTwist}) {
 		/call unpauseTwist
-		/varset	returnTwist FALSE
+		
 	}	
   	/if (${Debug} || ${Debug_Casting})  /echo |- e3_Cast -| castReturn= ${Cast.Result} ${castReturn}
 

--- a/Macros/e3 Includes/e3_Casting.inc
+++ b/Macros/e3 Includes/e3_Casting.inc
@@ -193,7 +193,7 @@ Sub e3_Cast(int targetID, ArrayName, int ArrayIndex, bool StopEchos)
 			}
 			/varset ActionTaken TRUE
 			/disc ${pendingCast}
-			/delay 5 !${Me.CombatAbilityReady[${pendingCast}]}
+			/delay 3
 		}
 	|-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	|- Abilities
@@ -201,7 +201,7 @@ Sub e3_Cast(int targetID, ArrayName, int ArrayIndex, bool StopEchos)
 		/if (${Me.AbilityReady[${pendingCast}]}) {
       	   /varset ActionTaken TRUE
 			/doability "${pendingCast}"
-			/delay 5 !${Me.AbilityReady[${pendingCast}]}
+			/delay 3 !${Me.AbilityReady[${pendingCast}]}
     	}
 	|-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	|- Spells, AA, Items

--- a/Macros/e3 Includes/e3_Casting.inc
+++ b/Macros/e3 Includes/e3_Casting.inc
@@ -54,46 +54,10 @@ Sub e3_Cast(int targetID, ArrayName, int ArrayIndex, bool StopEchos)
   |this allows other check_ Methods to run to do their computation while the spell is running
   |if they have to do an e3_Cast for their stuff, they will block here until the song is complete
   |if they don't do anything, it ends up blocking back in check_BardSongs for the next song on the list. 
-  /if (!${Twist.Twisting} && ${Me.Class.ShortName.Equal[BRD]}) {
-	   	/if (!${playingMelody}) {
-      		/echo issuing stopcast and kicking out
-      		/stopcast
-      		/goto :endBardSongLock
-    	}	 
-	   /while (${Window[CastingWindow].Open}) {
-		/doevents Follow
-		/if (!${Window[CastingWindow].Open}) {
-		/break
-		}
-		/doevents Stop
-		/if (!${Window[CastingWindow].Open}) {
-		/break
-		}
-		/doevents MoveHere
-		/if (!${Window[CastingWindow].Open}) {
-		/break
-		}
-		/doevents BackOff
-		/if (!${Window[CastingWindow].Open}) {
-		/break
-		}
-		/doevents clickit
-		/if (!${Window[CastingWindow].Open}) {
-		/break
-		}
-		/doevents bark
-		/if (!${Window[CastingWindow].Open}) {
-		/break
-		}
-		/call alerts_Background_Events
-		/if (!${Window[CastingWindow].Open}) {
-		/break
-		}
-		/delay 1
+	/if (!${Twist.Twisting} && ${Me.Class.ShortName.Equal[BRD]}) {
+	   
+	   /call BardSongWaitLockPumpQueue
 	}
-
-   }
-:endBardSongLock
   |if we are not using MQ2Twist, but we currently have a cast going yet no cast window, issue a stopcast
   /if (!${Twist.Twisting} && ${Me.Class.ShortName.Equal[BRD]} && ${Bool[${Me.Casting.ID}]} && !${${ArrayName}[${ArrayIndex},${iCastType}].Equal[Ability]} && !${${ArrayName}[${ArrayIndex},${iCastType}].Equal[Disc]} ) {
     |sometimes when the window is gone but the buff hasn't quite landed yet, stopcast can cancel it. delay 1 to make sure that situation is avoided
@@ -344,8 +308,10 @@ Sub e3_Cast(int targetID, ArrayName, int ArrayIndex, bool StopEchos)
 		/if (${Cast.Status.Find[C]} || ${Window[CastingWindow].Open}) {
 		  |dont allow item swap/must equip interrupts to avoid crashes
 
-
-			
+		   	/if (${Me.Class.ShortName.Equal[BRD]}) {
+				 /call ActivateSelosKick
+		   }
+		 	
 
 		  /if (${oldItem.Length}) {
 		    /delay 1

--- a/Macros/e3 Includes/e3_Casting.inc
+++ b/Macros/e3 Includes/e3_Casting.inc
@@ -134,15 +134,20 @@ Sub e3_Cast(int targetID, ArrayName, int ArrayIndex, bool StopEchos)
     }
   }
 
-	/if (${Twist.Twisting}) /call pauseTwist
-	/delay 3s !${Me.Casting.ID}
+	/if (${Twist.Twisting}) {
+		|this sets returnTwist to true
+		/call pauseTwist
+		/delay 3s !${Me.Casting.ID}
+		/delay 3
+	} 
+	
 
 	/declare startingLoc ${Me.Loc.Replace[ ,]}
 |~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 |  Casting
 :cast_spell
   |/if (${Me.Name.Equal[Lube]}) /gu Casting ${pendingCast} ${pendingCastID} ${Spawn[id ${targetID}].Name} ${targetID}
-	/if (!${StopEchos}) /echo Casting ${pendingCast} ${pendingCastID} ${Spawn[id ${targetID}].Name} ${targetID} in ${e3CastTime}
+	/if (!${StopEchos}) /echo [${Time}]: ${pendingCast} ${pendingCastID} ${Spawn[id ${targetID}].Name} ${targetID}
 	|~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	|Use Disc
 	/if (${${ArrayName}[${ArrayIndex},${iCastType}].Equal[Disc]}) {
@@ -157,15 +162,17 @@ Sub e3_Cast(int targetID, ArrayName, int ArrayIndex, bool StopEchos)
 				/delay 5 ${Target.ID} == ${targetID}
 			}
 			/varset ActionTaken TRUE
-			/disc ${pendingCast}
+			/disc "${pendingCast}""
+			/delay 3
 		}
 	|-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-	|- Abilities should never go to e3_cast, just a safeguard
+	|- Abilities
 	} else /if (${${ArrayName}[${ArrayIndex},${iCastType}].Equal[Ability]}) {
-		/if (${Me.AbilityReady[${abilityName}]}) {
-      /varset ActionTaken TRUE
-		  /doability ${pendingCast}
-    }
+		/if (${Me.AbilityReady[${pendingCast}]}) {
+      	   /varset ActionTaken TRUE
+			/doability "${pendingCast}"
+			/delay 3 !${Me.AbilityReady[${pendingCast}]}
+    	}
 	|-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	|- Spells, AA, Items
 	} else {
@@ -198,52 +205,66 @@ Sub e3_Cast(int targetID, ArrayName, int ArrayIndex, bool StopEchos)
 				/varset pendingType ${DefaultGem}
 			}
 		}
-    |/echo AT pendingCastID ${pendingCastID} pendingType ${pendingType}" "-targetid|${targetID}"
-	/varset ActionTaken TRUE
-	
-
-    /if (${${ArrayName}[${ArrayIndex},${iTargetType}].Equal[Self]}) {
-		/if (${Bool[${FindItem[=${pendingCast}]}]}) {
-
-			/useitem "${pendingCast}"
-			|set to a default good value unless overwritten for a reason
-			/varset castReturn CAST_SUCCESS
-			|Note when using /useitem, if the next 'cast' is a spell you need a 0.3 sec delay similar to bard songs.
-			|Possible optimizations to pass in to use the delay or not, but be warned, not using the delay
-			|and the spell is the next can get you to a point where your spell gems lock up and need to use an AA to fix.
-			/delay 3
-			
-
-		} else {
-			/casting "${pendingCastID}|${pendingType}"		
-		}
-    } else {
-		/if (${Bool[${FindItem[=${pendingCast}]}]}) {
-		    /declare i_target int local 0
-    		|/echo getting tareget for item
-			/for i 1 to 5
-				/if (${Bool[${Target.ID} != ${targetID}]}) {
-      				/target id ${targetID}
-      				/delay 1
-    			} else {
-					|ExitLoop if target is correct
-					/break
+		|/echo AT pendingCastID ${pendingCastID} pendingType ${pendingType}" "-targetid|${targetID}"
+		/varset ActionTaken TRUE
+		|to help with item clicks locking up, to give the server time to issue the cooldown.	
+   		/if (${pendingType.Equal[item]}) {
+   			|When an item delay is applied to an entry, check to see if the delay is still active
+			/if (${Defined[SpellRecast_${pendingCastID}]}) {
+				
+			/if (${SpellRecast_${pendingCastID}}) {
+				|our timer is still active, skip this and say we are not recovered yet.
+				|No action taken, so they can cast the next thing in the list.
+				/echo ${pendingCast} was tried again before cooldown complete, skipping this action with a CAST_RECOVER return value
+				/varset ActionTaken False
+				/varset castReturn CAST_RECOVER
+				/goto :skipCast
 			}
-			/next i_target
-			|/echo casting item "${pendingCast}" on ${targetID}
-			/useitem "${pendingCast}"
-			|set to a default good value unless overwritten for a reason
-			/varset castReturn CAST_SUCCESS
-			|Note when using /useitem, if the next 'cast' is a spell you need a 0.3 sec delay similar to bard songs.
-			|Possible optimizations to pass in to use the delay or not, but be warned, not using the delay
-			|and the spell is the next can get you to a point where your spell gems lock up and need to use an AA to fix.
-			/delay 3
-			|set to a default good value unless overwritten for a reason
-			
-		} else {
-			/casting "${pendingCastID}|${pendingType}" "-targetid|${targetID}"
+			}
 		}
-    }
+
+		/if (${${ArrayName}[${ArrayIndex},${iTargetType}].Equal[Self]}) {
+			/if (${Bool[${FindItem[=${pendingCast}]}]}) {
+
+				/useitem "${pendingCast}"
+				|set to a default good value unless overwritten for a reason
+				/varset castReturn CAST_SUCCESS
+				|Note when using /useitem, if the next 'cast' is a spell you need a 0.3 sec delay similar to bard songs.
+				|Possible optimizations to pass in to use the delay or not, but be warned, not using the delay
+				|and the spell is the next can get you to a point where your spell gems lock up and need to use an AA to fix.
+				/delay 3
+				
+
+			} else {
+				/casting "${pendingCastID}|${pendingType}"		
+			}
+		} else {
+			/if (${Bool[${FindItem[=${pendingCast}]}]}) {
+				/declare i_target int local 0
+				|/echo getting tareget for item
+				/for i 1 to 5
+					/if (${Bool[${Target.ID} != ${targetID}]}) {
+						/target id ${targetID}
+						/delay 1
+					} else {
+						|ExitLoop if target is correct
+						/break
+				}
+				/next i_target
+				|/echo casting item "${pendingCast}" on ${targetID}
+				/useitem "${pendingCast}"
+				|set to a default good value unless overwritten for a reason
+				/varset castReturn CAST_SUCCESS
+				|Note when using /useitem, if the next 'cast' is a spell you need a 0.3 sec delay similar to bard songs.
+				|Possible optimizations to pass in to use the delay or not, but be warned, not using the delay
+				|and the spell is the next can get you to a point where your spell gems lock up and need to use an AA to fix.
+				/delay 3
+				|set to a default good value unless overwritten for a reason
+				
+			} else {
+				/casting "${pendingCastID}|${pendingType}" "-targetid|${targetID}"
+			}
+		}
 		|- Memorizing spell
 		/if (${Cast.Status.Find[M]}) /delay 3s !${Cast.Status.Find[M]}
 		|- Set expected cast end time in 1/10ths of a second
@@ -378,9 +399,23 @@ Sub e3_Cast(int targetID, ArrayName, int ArrayIndex, bool StopEchos)
 		/call SwapItem "${oldItem}" "${${ArrayName}[${ArrayIndex},${iItemMustEquip}]}"
 	}
 	/if (${Following} && !${Assisting}) /call AcquireFollow
-  /if (${Me.Class.ShortName.Equal[BRD]}) /varset resumeTwistDelay 5
-  /if (${returnTwist})	/call unpauseTwist
-	/if (${Debug} || ${Debug_Casting})  /echo |- e3_Cast -| castReturn= ${Cast.Result} ${castReturn}
+  	/if (${Me.Class.ShortName.Equal[BRD]}) /varset resumeTwistDelay 5
+ 	|if the twist was stopped for this.
+	/if (${returnTwist})	/call unpauseTwist
+  	/if (${Debug} || ${Debug_Casting})  /echo |- e3_Cast -| castReturn= ${Cast.Result} ${castReturn}
+
+
+	|to help with item clicks locking up, to give the server time to issue the cooldown.	
+	/if (${Select[${castReturn},CAST_SUCCESS]} && ${pendingType.Equal[item]}) {
+			|when an item is click/cast, the server sends over the cooldown of said item
+			|so for a breif time between clicking there is an 'unknown' state where the items
+			|cooldown is still 0, even tho it isn't valid. Noticed this when using molten orbs.
+			|Adding a small delay to any item that is cast to prevent it from being a valid target
+			|on the next event cycle as event cycles in e3 are far faster than the server can send us
+			|the cooldown information
+			|/echo e3_Cast: Setting spell recast timer of 2 seconds
+			/call CreateTimer "SpellRecast_${pendingCastID}" "2s"
+	}
 
 |/varset Debug_Casting FALSE
 /return

--- a/Macros/e3 Includes/e3_Casting.inc
+++ b/Macros/e3 Includes/e3_Casting.inc
@@ -30,6 +30,24 @@ Sub e3_Cast(int targetID, ArrayName, int ArrayIndex, bool StopEchos)
 |StopEchos = Skips the /echo on successful cast if a value other than 0 is passed with the /call e3_Cast
 /if (${Debug} || ${Debug_Casting}) /echo |- e3_Cast ==>
 
+	|if we are a bard, and not doing async twisting this section of code
+	|will 'block' as the check_BardSongs does not block on its call.
+	|this allows other check_ Methods to run to do their computation while the spell is running
+	|if they have to do an e3_Cast for their stuff, they will block here until the song is complete
+	|if they don't do anything, it ends up blocking back in check_BardSongs for the next song on the list. 
+	/if (!${Twist.Twisting} && ${Me.Class.ShortName.Equal[BRD]}) {
+
+		/call BardSongWaitLockPumpQueue
+	}
+	|if we are not using MQ2Twist, but we currently have a cast going yet no cast window, issue a stopcast
+	/if (!${Twist.Twisting} && ${Me.Class.ShortName.Equal[BRD]} && ${Bool[${Me.Casting.ID}]} && !${${ArrayName}[${ArrayIndex},${iCastType}].Equal[Ability]} && !${${ArrayName}[${ArrayIndex},${iCastType}].Equal[Disc]} ) {
+		|sometimes when the window is gone but the buff hasn't quite landed yet, stopcast can cancel it. delay 1 to make sure that situation is avoided
+		/delay 1
+		/stopcast
+	}
+
+	|CatchAll Function for potentially locked up spell gems.
+  	/call check_SpellGemLockup
 
 	/declare beforeSpell string local ${${ArrayName}[${ArrayIndex},${iBeforeSpell}]}
 	/if (${beforeSpell.Length}>1) {
@@ -54,31 +72,13 @@ Sub e3_Cast(int targetID, ArrayName, int ArrayIndex, bool StopEchos)
 	
 
   |/varset Debug_Casting TRUE
-|~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-| Checks to abort casting due to previous failures
-  |if im invis and iCastInvis=0 (default except for heals)
-  |if im a rog, not in combat, done no action for 10+ seconds, and near 2+ other players then drop invis to buff (allows autohide)
-  
-  |if we are a bard, and not doing async twisting this section of code
-  |will 'block' as the check_BardSongs does not block on its call.
-  |this allows other check_ Methods to run to do their computation while the spell is running
-  |if they have to do an e3_Cast for their stuff, they will block here until the song is complete
-  |if they don't do anything, it ends up blocking back in check_BardSongs for the next song on the list. 
-	/if (!${Twist.Twisting} && ${Me.Class.ShortName.Equal[BRD]}) {
-	   
-	   /call BardSongWaitLockPumpQueue
-	}
-  |if we are not using MQ2Twist, but we currently have a cast going yet no cast window, issue a stopcast
-  /if (!${Twist.Twisting} && ${Me.Class.ShortName.Equal[BRD]} && ${Bool[${Me.Casting.ID}]} && !${${ArrayName}[${ArrayIndex},${iCastType}].Equal[Ability]} && !${${ArrayName}[${ArrayIndex},${iCastType}].Equal[Disc]} ) {
-    |sometimes when the window is gone but the buff hasn't quite landed yet, stopcast can cancel it. delay 1 to make sure that situation is avoided
-	/delay 1
-	/stopcast
-  }
-   
+ 
+ 
+	|~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	| Checks to abort casting due to previous failures
+	|if im invis and iCastInvis=0 (default except for heals)
+	|if im a rog, not in combat, done no action for 10+ seconds, and near 2+ other players then drop invis to buff (allows autohide)
 
-  |CatchAll Function for potentially locked up spell gems.
-  /call check_SpellGemLockup
-  
   /if (${Me.Invis}) {
     /if (${Me.Class.ShortName.Equal[Rog]}) {
       /if (!${Me.Combat} && ${SpawnCount[pc radius 40]} > 2 && !${SpawnCount[npc radius 100 zradius 100]} && ${idleTimer}<${Math.Calc[${idleInterval}*600 - 100]}) /makemevisible
@@ -268,11 +268,14 @@ Sub e3_Cast(int targetID, ArrayName, int ArrayIndex, bool StopEchos)
 		}
 		
 		/if (${${ArrayName}[${ArrayIndex},${iTargetType}].Equal[Self]}) {
-			|**/casting "${pendingCast}|${pendingType}"
+			/casting "${pendingCast}|${pendingType}"
 			/if (${pendingType.Equal[Item]}) {
 				/delay 3
-			}**|		
-			/if (${pendingType.Equal[Item]}) {
+			} else {
+				/delay 5
+			}		
+			
+			|**/if (${pendingType.Equal[Item]}) {
 
 				/useitem "${pendingCast}"
 				|set to a default good value unless overwritten for a reason
@@ -286,15 +289,17 @@ Sub e3_Cast(int targetID, ArrayName, int ArrayIndex, bool StopEchos)
 			} else {
 				/casting "${pendingCastID}|${pendingType}"
 				/delay 3		
-			}
+			}**|
 
 		} else {
-			|**/casting "${pendingCast}|${pendingType}" "-targetid|${targetID}"
+			|/echo /casting "${pendingCast}|${pendingType}" "-targetid|${targetID}"
+			/casting "${pendingCast}|${pendingType}" "-targetid|${targetID}"
 			/if (${pendingType.Equal[Item]}) {
 				/delay 3
-			}	
-			**|			
-			/if (${pendingType.Equal[Item]}) {
+			} else {
+				/delay 5
+			}		
+			|**/if (${pendingType.Equal[Item]}) {
 				/declare i_target int local 0
 				|/echo getting tareget for item
 				/for i 1 to 5
@@ -319,7 +324,7 @@ Sub e3_Cast(int targetID, ArrayName, int ArrayIndex, bool StopEchos)
 			} else {
 				/casting "${pendingCastID}|${pendingType}" "-targetid|${targetID}"
 				/delay 3
-			}
+			}**|
 		}
 		|- Memorizing spell
 		/if (${Cast.Status.Find[M]}) /delay 3s !${Cast.Status.Find[M]}
@@ -431,6 +436,12 @@ Sub e3_Cast(int targetID, ArrayName, int ArrayIndex, bool StopEchos)
 		|let the window fuly close
 		/delay 1
   :interrupted
+		|At this point the cast window is closed, but we may need to delay to get the result. 
+		|note, if we don't find the result in 2 seconds, soemthing has gone wrong
+		|it will use the previous cast return instead. There is a bug here for item lockups
+		|so we let this continue to loop back around and remove the item lock
+		/delay 2s !${Cast.Status.Find[C]}
+	
 		/varset castReturn ${Cast.Result}
 		|- Cast Result Processing
 		  /if (${castReturn.Equal[CAST_INTERRUPTED]} || ${interruptFlag}) {
@@ -490,6 +501,10 @@ Sub e3_Cast(int targetID, ArrayName, int ArrayIndex, bool StopEchos)
 	}
 
 |/varset Debug_Casting FALSE
+	|sometimes cast status gets locked up
+	|lets kill the current cast.
+	
+
 /return
 
 

--- a/Macros/e3 Includes/e3_Casting.inc
+++ b/Macros/e3 Includes/e3_Casting.inc
@@ -993,10 +993,16 @@ sub castSimpleSpellBase(spellName, simpleTargetID, SkipParams)
 	/call BuildSingleSpellArrayBase "${spellName}" "castSimpleSpellArray2D" ${SkipParams}
   
 	/call check_Ready "castSimpleSpellArray2D" 1
+	/declare checkReadyCounter int local 0
     /while (!${c_Ready}) {
+		/echo castSimpleSpellBase:check_Ready: not ready, waiting: ${spellName}
 		/delay 3
-		/echo checkready not ready, waiting
 		/call check_Ready "castSimpleSpellArray2D" 1		
+		/varcalc checkReadyCounter ${checkReadyCounter} +1
+		/if (${checkReadyCounter} > 6) {
+			/echo castSimpleSpellBase:check_Ready: failing after 6 attempts, kicking out. Things may break. 
+			/return
+		}
 	}
 	
     /call e3_Cast ${simpleTargetID} "castSimpleSpellArray2D" 1 False

--- a/Macros/e3 Includes/e3_Casting.inc
+++ b/Macros/e3 Includes/e3_Casting.inc
@@ -766,7 +766,7 @@ Sub casting_Setup
 	/varset vetArray[${iJester}]    "Chaotic Jester"
 	/call BuildSpellArray "vetArray" "vetArray2D"
 
-	/declare itemCooldownList[49,2] string local
+	/declare itemCooldownList[57,2] string local
 	/varset itemCooldownList[1,1] Summoned: Large Modulation Shard
 	/varset itemCooldownList[1,2] 300
 	/varset itemCooldownList[2,1] Shroud of the Subjugated Kuaan
@@ -865,10 +865,26 @@ Sub casting_Setup
 	/varset itemCooldownList[48,2] 180
 	/varset itemCooldownList[49,1] Academic's Robe of the Arcanists
 	/varset itemCooldownList[49,2] 300
+	/varset itemCooldownList[50,1] Whispering Tunic of Shadows
+	/varset itemCooldownList[50,2] 300
+	/varset itemCooldownList[51,1] Nightshade, Blade of Entropy
+	/varset itemCooldownList[51,2] 180
+	/varset itemCooldownList[52,1] Dawnseeker's Chestpiece of the Defender
+	/varset itemCooldownList[52,2] 300
+	/varset itemCooldownList[53,1] Nightbane, Sword of the Valiant
+	/varset itemCooldownList[53,2] 300
+	/varset itemCooldownList[54,1] Deathwhisper
+	/varset itemCooldownList[54,2] 180
+	/varset itemCooldownList[55,1] Bifold Focus of the Evil Eye
+	/varset itemCooldownList[55,2] 600
+	/varset itemCooldownList[56,1] Transcended Fistwraps of Immortality
+	/varset itemCooldownList[56,2] 180
+	/varset itemCooldownList[57,1] Fiercehand Shroud of the Focused
+	/varset itemCooldownList[57,2] 180
 
   	|scan through each of the items in itemCooldownList to see if we actually have that item, if so put it in the lookup list.
 
-	/declare tempItemLookupList[49,2] string local
+	/declare tempItemLookupList[57,2] string local
 	/declare tempItemLookupListCounter int local 1
 
 	/declare index int local 1

--- a/Macros/e3 Includes/e3_Casting.inc
+++ b/Macros/e3 Includes/e3_Casting.inc
@@ -394,7 +394,8 @@ Sub e3_Cast(int targetID, ArrayName, int ArrayIndex, bool StopEchos)
 					/call ${${ArrayName}[${ArrayIndex},${iSubToRun}]} ${ArrayName} ${ArrayIndex}
 
 					/if (!${c_SubToRun}) {
-           				/if (${Debug} || ${Debug_Casting}) /echo SubToRun called interrupt ${${ArrayName}[${ArrayIndex},${iSubToRun}]}
+					
+						/echo [${Time}]: E3_Cast SubToRun called interrupt for spell: ${pendingCast}
 					 	/call interrupt
 						/delay 3
 						/varset castReturn CAST_INTERRUPTED
@@ -411,7 +412,7 @@ Sub e3_Cast(int targetID, ArrayName, int ArrayIndex, bool StopEchos)
 				/doevents nowCast
 				|check to see if now Cast has decided to interrupt the casting.
 				/if (!${g_CastNowSpellCasting} && (!${c_SubToRun})) {
-							/if (${Debug} || ${Debug_Casting}) /echo nowCast called interrupt ${${ArrayName}[${ArrayIndex},${iSubToRun}]}
+							/echo [${Time}]: E3_Cast nowCast called interrupt ${${ArrayName}[${ArrayIndex},${iSubToRun}]}
 							/call interrupt
 							/delay 1s
 							/varset castReturn CAST_INTERRUPTED
@@ -689,24 +690,33 @@ Sub memorize_spell(spellName,gemNum)
 	
 	|only wait for beneficial,self spells
 	|(${Me.Combat} || ${Me.CombatState.Equal[Combat]} ||  ${AssistTarget} >0)
-
+	/declare isHealer bool Local ${Select[${Me.Class.ShortName},CLR,DRU,SHM]}
 	/declare timeTowait int local ${Math.Calc[35+(${Spell[${spellName}].RecastTime}/100)]}
-	/if ((${Me.Combat} || ${Me.CombatState.Equal[Combat]} ||  ${AssistTarget} >0)) {
-		/varset timeTowait 30
-	}
+	 /if (${isHealer} && ${timeTowait}>30) {
+        /varset timeTowait 30
+    } 
 	/declare waitForReady timer local ${timeTowait}
 	|/echo wfr ${waitForReady} rc ${Spell[${spellName}].RecastTime} math ${Math.Calc[25+(${Spell[${spellName}].RecastTime}/100)]}
 	:checkTimer
 		
 		|/echo chectimer ${waitForReady} ${Me.SpellReady[${spellName}]}
-		/if (${waitForReady}) {
+	/if (${waitForReady}) {
 		/doevents Follow
 		/doevents Stop
 		/doevents MoveHere
 		/doevents BackOff
+		/doevents Assist
 		/call alerts_Background_Events
-		/delay 1
-		/if (!${Me.SpellReady[${spellName}]}) /goto :checkTimer
+		
+		/if ((${Me.Combat} || ${Me.CombatState.Equal[Combat]} ||  ${AssistTarget} >0)) {
+			|kick out as we are now in combat
+			/return
+		}
+
+		/if (!${Me.SpellReady[${spellName}]}) {
+			/delay 1
+			/goto :checkTimer
+		}
 	}
 	
   /if (${Debug} || ${Debug_Casting}) /echo |- memorize_spell <=

--- a/Macros/e3 Includes/e3_Casting.inc
+++ b/Macros/e3 Includes/e3_Casting.inc
@@ -29,6 +29,15 @@
 Sub e3_Cast(int targetID, ArrayName, int ArrayIndex, bool StopEchos)
 |StopEchos = Skips the /echo on successful cast if a value other than 0 is passed with the /call e3_Cast
 /if (${Debug} || ${Debug_Casting}) /echo |- e3_Cast ==>
+
+
+	/declare beforeSpell string local ${${ArrayName}[${ArrayIndex},${iBeforeSpell}]}
+	/if (${beforeSpell.Length}>1) {
+		/if (${Me.SpellReady[${beforeSpell}]} || ${Me.AltAbilityReady[${beforeSpell}]} || ${Me.ItemReady[${beforeSpell}]} ) {
+			/call castSimpleSpell "${beforeSpell}" 0
+		}
+	}
+	/declare afterSpell string local ${${ArrayName}[${ArrayIndex},${iAfterSpell}]}
 	/varset pendingCast	${${ArrayName}[${ArrayIndex},${iCastName}]}
 	/varset pendingCastID ${${ArrayName}[${ArrayIndex},${iCastID}]}
 	/declare castTargetName string local ${Spawn[id ${targetID}].CleanName}
@@ -43,6 +52,8 @@ Sub e3_Cast(int targetID, ArrayName, int ArrayIndex, bool StopEchos)
 	|this needs to be set to true every run, as its checked for interrupt method calls. Technically they set it to true every time they run, but best to 
 	|be sure this is reset.
 	/varset c_SubToRun TRUE
+	
+
   |/varset Debug_Casting TRUE
 |~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 | Checks to abort casting due to previous failures
@@ -227,8 +238,10 @@ Sub e3_Cast(int targetID, ArrayName, int ArrayIndex, bool StopEchos)
 		|- Define item|alt|gem# parameter
 		/if (${${ArrayName}[${ArrayIndex},${iCastType}].Equal[AA]}) {
 			/varset pendingType alt
+			
 		} else /if (${${ArrayName}[${ArrayIndex},${iCastType}].Equal[Item]}) {
 			/varset pendingType item
+			
 		} else /if (${${ArrayName}[${ArrayIndex},${iCastType}].Equal[Spell]}) {
 			|- if Gem specified, use it, else use default
 			/if (${${ArrayName}[${ArrayIndex},${iSpellGem}]}) {
@@ -404,6 +417,8 @@ Sub e3_Cast(int targetID, ArrayName, int ArrayIndex, bool StopEchos)
 			}
 			/goto :cast_still_pending
 		}
+		|let the window fuly close
+		/delay 1
   :interrupted
 		/varset castReturn ${Cast.Result}
 		|- Cast Result Processing
@@ -454,6 +469,11 @@ Sub e3_Cast(int targetID, ArrayName, int ArrayIndex, bool StopEchos)
 			/call CreateTimer "SpellRecast_${pendingCastID}" "2s"
 	}
 
+	/if (${afterSpell.Length}>1) {
+		/if (${Me.SpellReady[${afterSpell}]} || ${Me.AltAbilityReady[${afterSpell}]} || ${Me.ItemReady[${afterSpell}]} ) {
+			/call castSimpleSpell "${afterSpell}" 0
+		}
+	}
 |/varset Debug_Casting FALSE
 /return
 

--- a/Macros/e3 Includes/e3_Casting.inc
+++ b/Macros/e3 Includes/e3_Casting.inc
@@ -371,7 +371,7 @@ Sub e3_Cast(int targetID, ArrayName, int ArrayIndex, bool StopEchos)
 |- check for reasons to cancel casting
 		
 		/if (${Window[CastingWindow].Open}) {
-		   /varset c_SubToRun True
+		 
 		  |dont allow item swap/must equip interrupts to avoid crashes
 			|/echo checking is still open
 		   	/if (${Me.Class.ShortName.Equal[BRD]}) {
@@ -395,10 +395,10 @@ Sub e3_Cast(int targetID, ArrayName, int ArrayIndex, bool StopEchos)
 					/call ${${ArrayName}[${ArrayIndex},${iSubToRun}]} ${ArrayName} ${ArrayIndex}
 
 					/if (!${c_SubToRun}) {
-					
+						/varset c_SubToRun True
 						/echo [${Time}]: E3_Cast SubToRun called interrupt for spell: ${pendingCast}
 					 	/call interrupt
-						/delay 3
+						/delay 1s
 						/varset castReturn CAST_INTERRUPTED
 						/goto :skipCast
 					}
@@ -413,7 +413,8 @@ Sub e3_Cast(int targetID, ArrayName, int ArrayIndex, bool StopEchos)
 				/doevents nowCast
 				|check to see if now Cast has decided to interrupt the casting.
 				/if (!${g_CastNowSpellCasting} && (!${c_SubToRun})) {
-							/echo [${Time}]: E3_Cast nowCast called interrupt ${${ArrayName}[${ArrayIndex},${iSubToRun}]}
+							/varset c_SubToRun True
+							/echo [${Time}]: E3_Cast nowCast called interrupt for ${pendingCast}
 							/call interrupt
 							/delay 3
 							/varset castReturn CAST_INTERRUPTED
@@ -761,6 +762,14 @@ Sub interrupt
     /if (!${NetBots[${Me.Name}].Mounted}) {
         /interrupt
     } 
+	|we don't leave this method unless the previous spell is stopped
+	|because of horses we just wait till the window is done, to preserve logic
+	|flow
+	/while (${Window[CastingWindow].Open}) {
+		/delay 1
+	}
+	
+
 /return
 
 |~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/Macros/e3 Includes/e3_Classes_Bard.inc
+++ b/Macros/e3 Includes/e3_Classes_Bard.inc
@@ -159,6 +159,13 @@ sub check_BardSongs
       /varset songGemValue ${Macro.Return}
       /call BardClass_CircularQueue_Insert "${songGemValue}"      
     }
+  } else /if (${songGemValue.Equal[Requiem of Time]}) {
+    /if (${Target.Buff[Requiem of Time].Duration.TotalSeconds}>30) {
+      |If the target already has the slow on, ignore it. and skip to the next song.
+      /call BardClass_CircularQueue_Pop
+      /varset songGemValue ${Macro.Return}
+      /call BardClass_CircularQueue_Insert "${songGemValue}"      
+    }
   }
  
   |End figuring out what song/item
@@ -316,6 +323,7 @@ SUB EVENT_startMelody(line, ChatSender, melodyName)
           |let gems reset
           /delay 3
       }
+      /stopcast
      
     } else /if (${Select[${melodyName},Pause]}) { 
       

--- a/Macros/e3 Includes/e3_Classes_Bard.inc
+++ b/Macros/e3 Includes/e3_Classes_Bard.inc
@@ -965,7 +965,7 @@ SUB delaySongCast(songName, myNhtTimerName)
 
 sub ActivateSelosKick
 
-  /if (${Target.ID} && ${Target.ID} == ${AssistTarget} && ${Me.AltAbilityReady[Selo's Kick]}  && ${Spawn[${Target}].Distance} < 25 ) {
+  /if (${Target.ID} && ${Target.ID} == ${AssistTarget} && ${Me.AltAbilityReady[Selo's Kick]}  && ${Spawn[${Target}].Distance} < 69 ) {
 
     /alt activate 8205
     /delay 5 !${Me.AltAbilityReady[Selo's Kick]}

--- a/Macros/e3 Includes/e3_Classes_Bard.inc
+++ b/Macros/e3 Includes/e3_Classes_Bard.inc
@@ -54,7 +54,9 @@ SUB EVENT_startMelody(line, ChatSender, melodyName)
         /varset playingMelody FALSE
         /varset songSet
         /docommand ${ChatToggle} Ending melody.
-        /twist end
+        /twist stop
+        |let gems reset
+        /delay 3
         /varset fixedMelody ${melodyName}
       } else {
         /docommand ${ChatToggle} [${melodyName}] is not a known melody.
@@ -113,15 +115,16 @@ SUB pauseTwist
 /if (${Debug} || ${Debug_Casting}) /echo |- pauseTwist ==>
 	/varset	returnTwist TRUE
 	/squelch /twist stop
-	/delay 2s !${Me.Casting.ID}
+	/delay 3s !${Me.Casting.ID}
+  /delay 3
 /if (${Debug} || ${Debug_Casting}) /echo <== pauseTwist -|
 /return
 |--------------------------------------------------------------|
 SUB unpauseTwist
-	/delay 2 !${Me.Casting.ID}
+	/delay 3s !${Me.Casting.ID}
 	/varset 	returnTwist FALSE
 	/if (${songPlayer.NotEqual["Dynamo"]}) /squelch 	/twist ${songSet}
-	/delay 2 ${Me.Casting.ID}
+	/delay 1s ${Me.Casting.ID}
 /return
 |--------------------------------------------------------------|
 #event toggleMez "<#1#> Mez #2#"

--- a/Macros/e3 Includes/e3_Classes_Bard.inc
+++ b/Macros/e3 Includes/e3_Classes_Bard.inc
@@ -991,31 +991,39 @@ sub BardSongWaitLockPumpQueue
 
   /doevents Follow
   /if (!${Window[CastingWindow].Open}) {
-  /break
+    /break
   }
   /doevents Stop
   /if (!${Window[CastingWindow].Open}) {
-  /break
+    /break
   }
   /doevents MoveHere
   /if (!${Window[CastingWindow].Open}) {
-  /break
+    /break
   }
   /doevents BackOff
   /if (!${Window[CastingWindow].Open}) {
-  /break
+    /break
   }
   /doevents clickit
   /if (!${Window[CastingWindow].Open}) {
-  /break
+    /break
   }
   /doevents bark
   /if (!${Window[CastingWindow].Open}) {
-  /break
+    /break
   }
   /call alerts_Background_Events
   /if (!${Window[CastingWindow].Open}) {
-  /break
+    /break
+  }
+  /doevents Assist
+  /if (!${Window[CastingWindow].Open}) {
+    /break
+  }
+  /doevents BackOff
+  /if (!${Window[CastingWindow].Open}) {
+    /break
   }
   /delay 1
 }

--- a/Macros/e3 Includes/e3_Classes_Bard.inc
+++ b/Macros/e3 Includes/e3_Classes_Bard.inc
@@ -299,9 +299,6 @@ SUB EVENT_startMelody(line, ChatSender, melodyName)
           /delay 3
       }
      
-      
-      /varset fixedMelody off
-
     } else /if (${Select[${melodyName},Pause]}) { 
       
       /call pauseTwist
@@ -325,7 +322,7 @@ SUB EVENT_startMelody(line, ChatSender, melodyName)
         /docommand ${ChatToggle} [${melodyName}] is not a known melody.
     } else {
           /varset currentMelody ${melodyName}
-          /varset fixedMelody ${melodyName}
+          |/varset fixedMelody ${melodyName}
           /declare spellName string local
           /declare i int local
           | For 1 to 7 (maximum melody size to include selos, 6 songs played actively with some droppage)
@@ -612,17 +609,16 @@ sub check_bard_mez
 SUB melodyIfs
 
   /if (!${playingMelody}) /return
-
   | when fixedMelody is stop, stop all melodies and don't let them start
   | when fixedMelody is off/null, start up MelodyIf again
   /if (!${Bool[${fixedMelody.Equal[off]}]} && !${currentMelody.Equal[${fixedMelody}]}) {
     
-    /echo if starting up melody ${fixedMelody}
+    |/echo if starting up melody ${fixedMelody}
 
     /call EVENT_startMelody "<${Me}> melody ${fixedMelody}" "${Me}" "${fixedMelody}"
     /return
   } else /if (${currentMelody.Equal[${fixedMelody}]}) {
-    | already set to one of the fixed melodies
+    |/echo  already set to one of the fixed melodies
     /return
   }
 
@@ -633,11 +629,12 @@ SUB melodyIfs
     /varset newIfMelody ${melodyIfs[${i},1]}
     /if (!${currentMelody.Equal[${newIfMelody}]} && (${melodyIfs[${i},2]})) {
        
-      /echo if starting up melody:${newIfMelody}
+      |/echo if starting up melody:${newIfMelody}
 
       /call EVENT_startMelody "<${Me}> melody ${newIfMelody}" "${Me}" "${newIfMelody}"
     }
   /next i
+ 
 /RETURN
 
 |--------------------------------------------------------------|
@@ -669,7 +666,7 @@ Sub BRD_Setup
   /call iniToVarV "${Character_Ini},Bard,Auto-Sonata (On/Off)" autoSonataOn bool outer
   /call iniToVarV "${Character_Ini},Bard,SongPlayer" songPlayer string outer
   /call iniToVarV "${Character_Ini},Bard,DynamoPrecastTime" dynamoPrecastTime int outer
-
+  /declare returnTwist bool outer False
   /if (!${Defined[songPlayer]}) {
     /echo Setting default SongPlayer to Twist
     /declare songPlayer string outer Twist
@@ -679,7 +676,7 @@ Sub BRD_Setup
     /declare dynamoPrecastTime int outer 4000
   }
 
-  /declare returnTwist		bool outer FALSE
+  
   /declare playingMelody	bool outer TRUE
   /declare songSet string outer
   /declare resumeTwistDelay timer outer

--- a/Macros/e3 Includes/e3_Classes_Bard.inc
+++ b/Macros/e3 Includes/e3_Classes_Bard.inc
@@ -1,6 +1,6 @@
 Sub BardClassDefinedValues
     |Create a circular queue with insert and pop methods
-    /declare bardSongArrayQueue[10] string outer
+    /declare bardSongArrayQueue[32] string outer
     /declare bardSongArrayQueueIndexFront int outer 0
     /declare bardSongArrayQueueIndexBack int outer -1
     /declare bardSongArrayQueueMax int outer 10
@@ -165,8 +165,15 @@ sub check_BardSongs
   |##########################
 
   /declare isItem bool local False
-  /if (${Bool[${FindItem[${songGemValue}]}]}) {
+  /declare isSpell bool local False
+  /declare isAltAbility bool local False
+
+ /if (${Bool[${Me.Book[${songGemValue}]}]}) {
+      /varset isSpell True
+  } else /if (${Bool[${FindItem[${songGemValue}]}]}) {
       /varset isItem True
+  } else /if (${Me.AltAbility[${songGemValue}]}) {
+      /varset isAltAbility true
   }
   
   /call ActivateSelosKick
@@ -188,14 +195,8 @@ sub check_BardSongs
   }
   |########
   |Cast the Song/Item
-  /if (${isItem}) {
-    |item isn't ready kickout
-    /if (!${Me.ItemReady[${songGemValue}]}) /return
-    /echo [${Time}]: Twist-Click: "${songGemValue}"
-    /useitem "${songGemValue}"
-    /delay 1
-   
-  } else {
+  |check for isSpell in case we have the actual spell in our inventory
+  /if (${isSpell}) {
   
     |is ths song ready? if not, kick out and loop back in
     /if (${songGemValue.Equal[Verse of Vesagran]}) { 
@@ -215,13 +216,30 @@ sub check_BardSongs
     |cast the song
     /cast "${songGemValue}"
     /echo [${Time}]: Twist: "${songGemValue}"
-    /delay 3
+    /delay 5 ${Window[CastingWindow].Open}
+    
     /if (!${Window[CastingWindow].Open}) {
       /echo [${Time}]: fizzle happened, recasting
+      /stopcast
+      /delay 1
       /cast ${songGemValue}
       /delay 3
     }
+  } else /if (${isItem}) {
+    |item isn't ready kickout
+    /if (!${Me.ItemReady[${songGemValue}]}) /return
+    /echo [${Time}]: Twist-Click: "${songGemValue}"
+    /useitem "${songGemValue}"
+    /delay 3
+   
+  } else /if (${isAltAbility}) {
+    /if (${Me.AltAbilityReady[${songGemValue}]}) {
+       /echo [${Time}]: Twist-Alt: "${songGemValue}"
+      /casting "${songGemValue}" alt
+			/delay 3 !${Me.AltAbilityReady[${pendingCast}]}   
+    }
   }
+
   |End cast of song/item
   |##############
 /return
@@ -331,18 +349,7 @@ SUB EVENT_startMelody(line, ChatSender, melodyName)
             /if (${melodyArray[${i}].Length} && ${melodyArray[${i}].NotEqual[PLACEHOLDER]}) {
               /varset spellName ${melodyArray[${i}].Arg[1,/]}
               | Check that the song is in my book or the item is in my inventory
-              /if (!${Me.Book[${spellName}]} && !${Bool[${FindItem[=${spellName}]}]}) {
-                /echo I don't have [${spellName}] in my spellbook and I don't have an item named [${spellName}], playing the melody without it.
-              } else /if (${Bool[${FindItem[=${spellName}]}]}) {
-                /call argueString gem| "${melodyArray[${i}]}"
-                /echo Found item for twist ${spellName}, will use item slot ${c_argueString}
-                /varset songList ${songList} ${c_argueString}
-                /if (${songPlayer.Equal["Twist"]}) {
-                     /call BardClass_CircularQueue_Insert  "${spellName}"
-                } else {
-                    /call BardClass_CircularQueue_Insert ${c_argueString}
-                }
-              } else {
+              /if (${Me.Book[${spellName}]}) {
                 | If the song is not memmed, use mq2Cast to mem
                 /if (!${Me.Gem[${spellName}]}) {
                   /call argueString gem| "${melodyArray[${i}]}"
@@ -362,7 +369,20 @@ SUB EVENT_startMelody(line, ChatSender, melodyName)
                     /call BardClass_CircularQueue_Insert  "${Me.Gem[${spellName}]}"
                 }
                 
-              }
+              } else /if (${Bool[${FindItem[=${spellName}]}]}) {
+                /call argueString gem| "${melodyArray[${i}]}"
+                /echo Found item for twist ${spellName}, will use item slot ${c_argueString}
+                /varset songList ${songList} ${c_argueString}
+                /if (${songPlayer.Equal["Twist"]}) {
+                     /call BardClass_CircularQueue_Insert  "${spellName}"
+                } else {
+                    /call BardClass_CircularQueue_Insert ${c_argueString}
+                }
+              } else /if (${songPlayer.Equal["Twist"]} && ${Me.AltAbility[${spellName}]} ) {
+                   /call BardClass_CircularQueue_Insert  "${spellName}"
+              } else {
+                /echo I don't have [${spellName}], playing the melody without it.
+              } 
             }
           /next i
         

--- a/Macros/e3 Includes/e3_Classes_Bard.inc
+++ b/Macros/e3 Includes/e3_Classes_Bard.inc
@@ -1,3 +1,111 @@
+Sub BardClassDefinedValues
+    |Create a circular queue with insert and pop methods
+    /declare bardSongArrayQueue[10] string outer
+    /declare bardSongArrayQueueIndexFront int outer 0
+    /declare bardSongArrayQueueIndexBack int outer -1
+    /declare bardSongArrayQueueMax int outer 10
+    /declare bardSongArrayQueueCount int outer 0
+ 	
+/RETURN
+Sub BardClass_CircularQueue_Insert(InsertValue)
+    /if (${bardSongArrayQueueCount}==${bardSongArrayQueueMax}) {
+        /echo BardClass Queue Overflow, throwing away ${InsertValue}
+        /return
+    }
+    /varset bardSongArrayQueueIndexBack ${Math.Calc[(${bardSongArrayQueueIndexBack} + 1) % ${bardSongArrayQueueMax}]}
+    |Array indexes starting at 1 is stupid and the person should be flogged with a wet fish
+    /declare arrayIndex int local ${Math.Calc[${bardSongArrayQueueIndexBack}+1]}
+    |/echo Insert. Front:${bardSongArrayQueueIndexFront} back:${bardSongArrayQueueIndexBack}, index of ${arrayIndex} with value ${InsertValue}
+    
+    /varset bardSongArrayQueue[${arrayIndex}] ${InsertValue}
+    /varcalc bardSongArrayQueueCount ${bardSongArrayQueueCount}+1
+
+
+/return
+
+
+Sub BardClass_CircularQueue_Pop
+    /if (${bardSongArrayQueueCount}==0) {
+        /echo BardClass Queue Empty Already
+        /return
+    }
+    /declare arrayIndex int local ${Math.Calc[${bardSongArrayQueueIndexFront}+1]}
+    /declare returnValue string local ${bardSongArrayQueue[${arrayIndex}]}
+    /varset bardSongArrayQueueIndexFront ${Math.Calc[(${bardSongArrayQueueIndexFront} + 1) % ${bardSongArrayQueueMax}]}
+    
+    /varcalc bardSongArrayQueueCount ${bardSongArrayQueueCount}-1
+    
+    |/echo Poping ArrayIndex:${arrayIndex} with returnValue:${returnValue}
+  
+/return ${returnValue}
+
+Sub BardClass_CircularQueue_Empty
+    /varset bardSongArrayQueueCount 0
+    /varset bardSongArrayQueueIndexFront 0
+    /varset bardSongArrayQueueIndexBack -1
+
+/return
+
+Sub BardClass_CircularQueue_Peek
+    /if (${bardSongArrayQueueCount}==0) {
+        /echo BardClass Queue Empty Already
+        /return
+    }
+    /declare returnValue string local ${bardSongArrayQueue[${Math.Calc[${bardSongArrayQueueIndexFront}+1]}]}
+    
+/return ${returnValue}
+
+|0 based index
+Sub BardClass_CircularQueue_PeekIndex(indexValue)
+    /if (${bardSongArrayQueueCount}==0) {
+        /echo BardClass Queue Empty Already
+        /return
+    }
+   
+    /declare arrayIndex int local  ${Math.Calc[(${bardSongArrayQueueIndexFront} + ${indexValue} ) % ${bardSongArrayQueueMax}]}
+    /varCalc arrayIndex ${arrayIndex}+1
+    /declare returnValue string local ${bardSongArrayQueue[${arrayIndex}]}
+    |/echo PeekIndex Front:${bardSongArrayQueueIndexFront} back:${bardSongArrayQueueIndexBack}  of input index: ${indexValue}, array index:${arrayIndex} return value: ${returnValue}
+
+/return ${returnValue}
+
+Sub BardClass_CircularQueue_PrintQueue
+  /if (${bardSongArrayQueueCount}==0) {
+    /echo BardClass Queue Empty Already
+    /return
+  }
+  /declare counter int local 0
+  /declare itemValue string local
+
+  |loop through the current queue,
+  /while (${counter}< ${bardSongArrayQueueCount}) {
+    /call BardClass_CircularQueue_PeekIndex ${counter}
+    /varset itemValue ${Macro.Return}
+    /echo ${counter}) ${itemValue}
+    /varcalc counter ${counter}+1
+  }
+    
+/return
+
+
+Sub BardClass_CircularQueue_ToString
+  /if (${bardSongArrayQueueCount}==0) {
+    /echo BardClass Queue Empty Already
+    /return
+  }
+  /declare counter int local 0
+  /declare itemValue string local
+  /declare returnValue string local
+  |loop through the current queue,
+  /while (${counter}< ${bardSongArrayQueueCount}) {
+    /call BardClass_CircularQueue_PeekIndex ${counter}
+    /varset itemValue ${Macro.Return}
+    /varset returnValue ${returnValue} ${itemValue}
+    /varcalc counter ${counter}+1
+  }
+    
+/return ${returnValue}
+
 |----------------------------------------------------------------------------|
 | Bard Functions
 |----------------------------------------------------------------------------|
@@ -36,95 +144,195 @@ SUB EVENT_saveMelody(line, ChatSender, melodyName, songsToSave)
 /if (${Debug}) /echo <== EVENT_saveMelody -|
 /return
 |------------------------------------------------------------------------|
+
 #EVENT startMelody "<#1#> Melody #2#"
 #EVENT startMelody "[#1#] Melody #2#"
 #EVENT startMelody "#1# tells you, 'Melody #2#'"
+
 SUB EVENT_startMelody(line, ChatSender, melodyName)
-/if (${Debug}) /echo |- EVENT_startMelody ==>
-  /if (${Me.Class.ShortName.Equal[BRD]}) {
-    /if (!${checkEventArgs[${ChatSender},${line},UZR,${melodyName}]}) /return
-    /varset currentMelody ${melodyName}
-    /declare memGem int local
-    /varset melodyName ${c_eventArgData}
-    | If I don't have the melodyName listed in my ini.
+  
+  /if (!${Me.Class.ShortName.Equal[BRD]}) /return
+
+  /if (${Debug}) /echo |- EVENT_startMelody ==>
+
+  |getting the melody name via c_eventArgs? odd 
+  /if (!${checkEventArgs[${ChatSender},${line},UZR,${melodyName}]}) /return
+  /varset currentMelody ${melodyName}
+
+  /varset melodyName ${c_eventArgData}
+  /declare memGem int local
+  /declare songList string local
+  
+  |check for commands first
+  /if (${Select[${melodyName},Stop,End,Pause,Resume]}) {
+    | If Stop, end, or pause were used, stop the melody.
+    /if (${Select[${melodyName},Stop,End]}) {
+      |empty out the queue
+      /call BardClass_CircularQueue_Empty
+
+      /varset playingMelody FALSE
+      /varset songSet
+      /docommand ${ChatToggle} Ending melody.
+      /twist stop
+      |let gems reset
+      /delay 3
+      /echo setting fixedMelody to off
+      /varset fixedMelody off
+
+    } else /if (${Select[${melodyName},Pause]}) { 
+      
+      /call pauseTwist
+
+    } else /if (${Select[${melodyName},Resume]}) { 
+
+      /call unpauseTwist
+
+    } else {
+
+      /docommand ${ChatToggle} EVENT_startMelody [${melodyName}] is not a known melody.
+    }
+    |###### RESUME END
+  } else {
+    |now lets check for melodies sent to us
+    /call BardClass_CircularQueue_Empty
+    
     /call IniToArrayV "${Character_Ini},${melodyName} Melody,Song#" melodyArray
     /if (!${Defined[melodyArray]}) {
-      | If Stop, end, or pause were used, stop the melody.
-      /if (${Select[${melodyName},Stop,End,Pause]}) {
-        /varset playingMelody FALSE
-        /varset songSet
-        /docommand ${ChatToggle} Ending melody.
-        /twist stop
-        |let gems reset
-        /delay 3
-        /varset fixedMelody ${melodyName}
-      } else {
         /docommand ${ChatToggle} [${melodyName}] is not a known melody.
-      }
     } else {
-      /declare songList string local
-      /declare spellName string local
-      /declare i int local
-      | For 1 to 7 (maximum melody size to include selos, 6 songs played actively with some droppage)
-      /for i 1 to ${melodyArray.Size}
-      |/echo ${i} ${melodyArray[${i}]}
-      /if (${melodyArray[${i}].Length} && ${melodyArray[${i}].NotEqual[PLACEHOLDER]}) {
-        /varset spellName ${melodyArray[${i}].Arg[1,/]}
-        | Check that the song is in my book or the item is in my inventory
-        /if (!${Me.Book[${spellName}]} && !${Bool[${FindItem[=${spellName}]}]}) {
-          /echo I don't have [${spellName}] in my spellbook and I don't have an item named [${spellName}], playing the melody without it.
-        } else /if (${Bool[${FindItem[=${spellName}]}]}) {
-          /call argueString gem| "${melodyArray[${i}]}"
-          /echo Found item for twist ${spellName}, will use item slot ${c_argueString}
-          /varset songList ${songList} ${c_argueString}
-        } else {
-          | If the song is not memmed, use mq2Cast to mem
-          /if (!${Me.Gem[${spellName}]}) {
-            /call argueString gem| "${melodyArray[${i}]}"
-            /if (${Bool[${c_argueString}]}) {
-              /varset memGem ${c_argueString}
-            } else {
-              /varset memGem ${DefaultGem}
+
+          /varset fixedMelody ${melodyName}
+          /declare spellName string local
+          /declare i int local
+          | For 1 to 7 (maximum melody size to include selos, 6 songs played actively with some droppage)
+          /for i 1 to ${melodyArray.Size}
+            |/echo ${i} ${melodyArray[${i}]}
+            /if (${melodyArray[${i}].Length} && ${melodyArray[${i}].NotEqual[PLACEHOLDER]}) {
+              /varset spellName ${melodyArray[${i}].Arg[1,/]}
+              | Check that the song is in my book or the item is in my inventory
+              /if (!${Me.Book[${spellName}]} && !${Bool[${FindItem[=${spellName}]}]}) {
+                /echo I don't have [${spellName}] in my spellbook and I don't have an item named [${spellName}], playing the melody without it.
+              } else /if (${Bool[${FindItem[=${spellName}]}]}) {
+                /call argueString gem| "${melodyArray[${i}]}"
+                /echo Found item for twist ${spellName}, will use item slot ${c_argueString}
+                /varset songList ${songList} ${c_argueString}
+                /call BardClass_CircularQueue_Insert ${c_argueString}
+              } else {
+                | If the song is not memmed, use mq2Cast to mem
+                /if (!${Me.Gem[${spellName}]}) {
+                  /call argueString gem| "${melodyArray[${i}]}"
+                  /if (${Bool[${c_argueString}]}) {
+                    /varset memGem ${c_argueString}
+                  } else {
+                    /varset memGem ${DefaultGem}
+                  }
+                  /memorize "${spellName}" "${memGem}"
+                  /if (${Cast.Status.Find[M]}) /delay 3s !${Cast.Status.Find[M]}
+                } 
+                | Update songList with the corresponding gem#
+                /varset songList ${songList} ${Me.Gem[${spellName}]}
+                /call BardClass_CircularQueue_Insert  "${Me.Gem[${spellName}]}"
+              }
             }
-            /memorize "${spellName}" "${memGem}"
-            /if (${Cast.Status.Find[M]}) /delay 3s !${Cast.Status.Find[M]}
-          } 
-          | Update songList with the corresponding gem#
-          /varset songList ${songList} ${Me.Gem[${spellName}]}
+          /next i
+        
+          | If I have a songList, start singing the melody
+          /if (${Bool[${songList}]}) {
+            | Twist the newly built songList.
+            /varset playingMelody TRUE
+            /varset returnTwist FALSE
+            /varset songSet ${songList}
+            |/echo singing Songset: ${songList}
+            /docommand ${ChatToggle} Playing New Melody: [${melodyName}].
+          
+            /if (${songPlayer.NotEqual["Dynamo"]}) /twist ${songSet}
+          }
         }
-        /next i
-      }
-      | If I have a songList, start singing the melody
-      /if (${Bool[${songList}]}) {
-        | Twist the newly built songList.
-        /varset playingMelody TRUE
-        /varset returnTwist FALSE
-        /varset songSet ${songList}
-        /docommand ${ChatToggle} Playing [${melodyName}].
-        /if (${fixedMelody.Equal[stop]}) {
-          /varset fixedMelody off
-        }
-        /if (${songPlayer.NotEqual["Dynamo"]}) /twist ${songSet}
-      }
     }
-  }
+
+ 
+  :endStartMelody
+  
+  |for debug purposes
+  |/call BardClass_CircularQueue_PrintQueue
+
 /if (${Debug}) /echo <== EVENT_startMelody -|
+
 /return
 |--------------------------------------------------------------|
 SUB pauseTwist
 /if (${Debug} || ${Debug_Casting}) /echo |- pauseTwist ==>
 	/varset	returnTwist TRUE
-	/squelch /twist stop
-	/delay 3s !${Me.Casting.ID}
-  /delay 3
+	
+  | just stop the quest and reorganize the playlist
+
+      /varset playingMelody FALSE
+      /varset songSet
+      /docommand ${ChatToggle} Pausing: ${fixedMelody}.
+      /twist stop
+      |let gems reset
+      /delay 3
+      
+      /declare counter int local 0
+      /declare songGemValue string local
+
+      |loop through the current queue, poping off at the front, and reinserting back at the end
+      /while (${counter}< ${bardSongArrayQueueCount}) {
+        /call BardClass_CircularQueue_Peek
+        /varset songGemValue ${Macro.Return}
+        |found the variable that equals the last gem played
+        /if (!${songGemValue.Equal[${previousSpellGemThatWasCast}]}) {
+
+              /call BardClass_CircularQueue_Pop
+              /varset songGemValue ${Macro.Return}
+              /call BardClass_CircularQueue_Insert "${songGemValue}"
+
+        } else {
+
+          |it equals so kick out we are done
+          /break
+        } 
+        /varcalc counter ${counter}+1
+      }      
+  
+  
 /if (${Debug} || ${Debug_Casting}) /echo <== pauseTwist -|
 /return
 |--------------------------------------------------------------|
+--------------------------------------------------------------|
 SUB unpauseTwist
 	/delay 3s !${Me.Casting.ID}
-	/varset 	returnTwist FALSE
-	/if (${songPlayer.NotEqual["Dynamo"]}) /squelch 	/twist ${songSet}
-	/delay 1s ${Me.Casting.ID}
+	
+  /if (!${Bool[${playingMelody}]}) {
+     /declare songList string local
+    |###### RESUME
+    |reread the playlist and start up the twist again
+    /if (${bardSongArrayQueueCount}>0) {
+      
+      /call BardClass_CircularQueue_ToString
+      /varset songList ${Macro.Return}
+      
+      | Twist the newly built songList.
+      /varset playingMelody TRUE
+      /varset returnTwist FALSE
+      /varset songSet ${songList}
+      |/echo singing Songset: ${songList}
+      /docommand ${ChatToggle} Unpause [${fixedMelody}].
+      /if (${songPlayer.NotEqual["Dynamo"]}) {
+       
+        /twist ${songSet}
+      } 
+      /delay 1s ${Me.Casting.ID}
+    
+    } else {
+
+      /docommand ${ChatToggle} No melody to resume.
+    }
+  } else {
+    /docommand ${ChatToggle} unpauseTwist: [${fixedMelody}] is not a known melody.
+  }
+  |###### RESUME END
+
 /return
 |--------------------------------------------------------------|
 #event toggleMez "<#1#> Mez #2#"

--- a/Macros/e3 Includes/e3_Classes_Bard.inc
+++ b/Macros/e3 Includes/e3_Classes_Bard.inc
@@ -989,51 +989,59 @@ sub BardSongWaitLockPumpQueue
   } 
 |Block in case we are currently casting a previous song
   /while (${Window[CastingWindow].Open}) {
-  /doevents startMelody
-  /if (!${playingMelody}) {
-    /echo issuing stopcast and kicking out
-    /stopcast
-    /return
-  }
-  /call ActivateSelosKick
+    
+    /doevents nowCast
 
-  /doevents Follow
-  /if (!${Window[CastingWindow].Open}) {
-    /break
+    /if (${nowSpellArrayQueueCount}>0) {
+        |check to see if we have spell(s) ready in nowCast that may have interrupted the above call
+        /call castNowSpells
+
+    }
+    /doevents startMelody
+    /if (!${playingMelody}) {
+      /echo issuing stopcast and kicking out
+      /stopcast
+      /return
+    }
+    /call ActivateSelosKick
+
+    /doevents Follow
+    /if (!${Window[CastingWindow].Open}) {
+      /break
+    }
+    /doevents Stop
+    /if (!${Window[CastingWindow].Open}) {
+      /break
+    }
+    /doevents MoveHere
+    /if (!${Window[CastingWindow].Open}) {
+      /break
+    }
+    /doevents BackOff
+    /if (!${Window[CastingWindow].Open}) {
+      /break
+    }
+    /doevents clickit
+    /if (!${Window[CastingWindow].Open}) {
+      /break
+    }
+    /doevents bark
+    /if (!${Window[CastingWindow].Open}) {
+      /break
+    }
+    /call alerts_Background_Events
+    /if (!${Window[CastingWindow].Open}) {
+      /break
+    }
+    /doevents Assist
+    /if (!${Window[CastingWindow].Open}) {
+      /break
+    }
+    /doevents BackOff
+    /if (!${Window[CastingWindow].Open}) {
+      /break
+    }
+    /delay 1
   }
-  /doevents Stop
-  /if (!${Window[CastingWindow].Open}) {
-    /break
-  }
-  /doevents MoveHere
-  /if (!${Window[CastingWindow].Open}) {
-    /break
-  }
-  /doevents BackOff
-  /if (!${Window[CastingWindow].Open}) {
-    /break
-  }
-  /doevents clickit
-  /if (!${Window[CastingWindow].Open}) {
-    /break
-  }
-  /doevents bark
-  /if (!${Window[CastingWindow].Open}) {
-    /break
-  }
-  /call alerts_Background_Events
-  /if (!${Window[CastingWindow].Open}) {
-    /break
-  }
-  /doevents Assist
-  /if (!${Window[CastingWindow].Open}) {
-    /break
-  }
-  /doevents BackOff
-  /if (!${Window[CastingWindow].Open}) {
-    /break
-  }
-  /delay 1
-}
 
 /RETURN

--- a/Macros/e3 Includes/e3_Classes_Bard.inc
+++ b/Macros/e3 Includes/e3_Classes_Bard.inc
@@ -669,7 +669,7 @@ SUB event_setFixedMelody(line, ChatSender, melodyName)
 
 | Automatically cast Selo's Sonata whenever the buff is missing on the Bard
 SUB autoSonata
-  /if (${autoSonataOn} && (!${Me.Buff[Selo's Sonata].ID} || ${Me.Buff[Selo's Sonata].Duration} < 10000) && !${Me.Invis} && ${Me.AltAbilityReady[Selo's Sonata]}) {
+  /if (${autoSonataOn} && (!${Me.Buff[Selo's Sonata].ID} || ${Me.Buff[Selo's Sonata].Duration.TotalSeconds} < 10) && !${Me.Invis} && ${Me.AltAbilityReady[Selo's Sonata]}) {
     /alt act 3704
   }
 /RETURN

--- a/Macros/e3 Includes/e3_Classes_Bard.inc
+++ b/Macros/e3 Includes/e3_Classes_Bard.inc
@@ -122,8 +122,13 @@ sub check_BardSongs
   }
   /if (${Bool[${Me.Casting.ID}]} ) {
     |turn off our current song so we can start a new one
-     /cast ${Me.Gem[${Me.Casting}]}
-     |/delay 1
+    /if (${Bool[${Me.Gem[${Me.Casting}]}]}) {
+      /cast ${Me.Gem[${Me.Casting}]}
+    } else {
+      |an item cast most likely, we have to click some valid gem
+      |TODO:hard code for now, do a loop later
+      /cast 1
+    }
   }
   |we are not  casting, cast the next spell in the list. 
   /call BardClass_CircularQueue_Pop
@@ -131,8 +136,7 @@ sub check_BardSongs
   /varset songGemValue ${Macro.Return}
   /call BardClass_CircularQueue_Insert "${songGemValue}"
   
-  |/if (${Me.Gem[${songGemValue}].Name.Equal[Selo's Accelerating Chorus]}) {
-   /if (${songGemValue.Equal[Selo's Accelerating Chorus]}) {
+  /if (${songGemValue.Equal[Selo's Accelerating Chorus]}) {
     /if (${Me.Buff[Selo's Accelerating Chorus].Duration.TotalSeconds}>45) {
       |we already have the buff up and it has > 45 seconds left, skip it
       |/echo Skipping Selo's Accelerating Chorus as it has time left
@@ -141,52 +145,61 @@ sub check_BardSongs
       /call BardClass_CircularQueue_Insert "${songGemValue}"      
     }
   }
-    
-  |/call castSimpleSpell "${Me.Gem[${songGemValue}]}" 0
-  |/declare castTime int local ${Spell[${Me.Gem[${songGemValue}]}].MyCastTime}
+
+  /declare isItem bool local False
+
+  /while (true) {
+    |check to see if the select spell/item is ready to cast.
+  
+    /if (${Bool[${FindItem[${songGemValue}]}]}) {
+      /varset isItem True
+    }
+
+    /if (${isItem}) {
+
+        /if (!${Me.ItemReady[${songGemValue}]}) {
+            /echo [${Time}]: Not Ready Skpping:${songGemValue}
+            |skip to the next song
+            /call BardClass_CircularQueue_Pop
+            /varset songGemValue ${Macro.Return}
+            /call BardClass_CircularQueue_Insert "${songGemValue}"    
+        } else {
+          /break
+        }
 
 
-  /if (${Bool[${FindItem[${songGemValue}]}]}) {
-    /declare castTime int local ${FindItem[${songGemValue}].CastTime}
-  } else {
-    /declare castTime int local ${Spell[${songGemValue}].MyCastTime}
-    
+    } else {
+        /if (!${Me.SpellReady[${songGemValue}]}) {
+            |skip to the next song
+            /echo [${Time}]: Not Ready Skpping:${songGemValue}
+            /call BardClass_CircularQueue_Pop
+            /varset songGemValue ${Macro.Return}
+            /call BardClass_CircularQueue_Insert "${songGemValue}"    
+        } else {
+          /break
+        }
+    }
+
   }
   
-  /if (${castTime}<100) {
-    /varset castTime 100
-  }
-  /declare delayTime int local ${Math.Calc[${castTime}/100]}
-  
-  /varcalc delayTime ${delayTime} 
-
-  /if (${delayTime}<5) {
-    /varset delayTime 5
-  }
-  /if (${Bool[${FindItem[${songGemValue}]}]}) {
+  /if (${isItem}) {
+    /echo [${Time}]: Twist-Click: "${songGemValue}"
     /useitem "${songGemValue}"
-   
+    /delay 1
+
   } else {
+    /echo [${Time}]: Twist: "${songGemValue}"
     /cast "${songGemValue}"
-    /delay 3 ${Window[CastingWindow].Open}
-    /delay 5
+    |need a delay of 3 to detect a missed song
+    /delay 3
     /if (!${Window[CastingWindow].Open}) {
-      /echo fizzle happened, recasting
+      /echo [${Time}]: fizzle happened, recasting
       /cast ${songGemValue}
-      /varcalc delayTime ${Math.Calc[${castTime}/100]}
-      /delay 5
+      /delay 1
     }
     
   }
-  
-  
-  |/echo [${Time}]: ${Me.Gem[${songGemValue}]} | ${delayTime}
-  |/echo [${Time}]: ${songGemValue} | ${delayTime}
-
-  /while (${delayTime}>0) {
-     /if (!${Window[CastingWindow].Open}) {
-       /break
-     }
+  /while (${Window[CastingWindow].Open}) {
     /doevents Follow
     /if (!${Window[CastingWindow].Open}) {
        /break
@@ -216,9 +229,8 @@ sub check_BardSongs
        /break
      }
     /delay 1
-    /varcalc delayTime ${delayTime} -1
   }
-  |/delay ${delayTime}
+  
   
 /return
 
@@ -382,9 +394,9 @@ SUB pauseTwist
 /if (${Debug} || ${Debug_Casting}) /echo |- pauseTwist ==>
 	
   /varset playingMelody FALSE
-  /return
   /varset	returnTwist TRUE
-	
+  /return
+ 	
   | just stop the quest and reorganize the playlist
 
       /varset playingMelody FALSE
@@ -586,6 +598,7 @@ sub check_bard_mez
 
 | Change melodies based on MelodyIf statements
 SUB melodyIfs
+  /if (!${playingMelody}) /return
   | when fixedMelody is stop, stop all melodies and don't let them start
   | when fixedMelody is off/null, start up MelodyIf again
   /if (!${Bool[${fixedMelody.Equal[off]}]} && !${currentMelody.Equal[${fixedMelody}]}) {

--- a/Macros/e3 Includes/e3_Classes_Bard.inc
+++ b/Macros/e3 Includes/e3_Classes_Bard.inc
@@ -112,27 +112,32 @@ Sub BardClass_CircularQueue_ToString
 |----------------------------------------------------------------------------|
 
 sub check_BardSongs
-
+  
+  /if (!${songPlayer.Equal["Twist"]} || ${Me.Invis} || ${Me.Stunned}) {
+      /return
+  }
+  |don't do songs when looting
+  /if (${Target.CleanName.Equal[${Me}'s corpse]}) { 
+      /return 
+  } 
+  /if (!${playingMelody} && !${fixedMelody.Equal[off]}) {
+    
+    /if (${Bool[${Me.Casting.ID}]} ) {
+      /echo issuing stopcast2 and kicking out
+      /stopcast
+    } 
+    /return
+  }   
   /if (!${playingMelody}) /return
+  
   /if (${bardSongArrayQueueCount}==0) {
     /return
   }
-  /if (${Window[CastingWindow].Open}) {
-    /return
-  }
-  /if (${Bool[${Me.Casting.ID}]} ) {
-    |turn off our current song so we can start a new one
-    /if (${Bool[${Me.Gem[${Me.Casting}]}]}) {
-      /cast ${Me.Gem[${Me.Casting}]}
-    } else {
-      |an item cast most likely, we have to click some valid gem
-      |TODO:hard code for now, do a loop later
-      /cast 1
-    }
-  }
-  |we are not  casting, cast the next spell in the list. 
+  |######################################################
+  |Figure out the next song on the list to play
   /call BardClass_CircularQueue_Pop
   /declare songGemValue string local
+  /declare nextGemValue string local
   /varset songGemValue ${Macro.Return}
   /call BardClass_CircularQueue_Insert "${songGemValue}"
   
@@ -145,93 +150,106 @@ sub check_BardSongs
       /call BardClass_CircularQueue_Insert "${songGemValue}"      
     }
   }
+ 
+  |End figuring out what song/item
+  |##########################
 
   /declare isItem bool local False
-
-  /while (true) {
-    |check to see if the select spell/item is ready to cast.
-  
-    /if (${Bool[${FindItem[${songGemValue}]}]}) {
+  /if (${Bool[${FindItem[${songGemValue}]}]}) {
       /varset isItem True
-    }
-
-    /if (${isItem}) {
-
-        /if (!${Me.ItemReady[${songGemValue}]}) {
-            /echo [${Time}]: Not Ready Skpping:${songGemValue}
-            |skip to the next song
-            /call BardClass_CircularQueue_Pop
-            /varset songGemValue ${Macro.Return}
-            /call BardClass_CircularQueue_Insert "${songGemValue}"    
-        } else {
-          /break
-        }
-
-
-    } else {
-        /if (!${Me.SpellReady[${songGemValue}]}) {
-            |skip to the next song
-            /echo [${Time}]: Not Ready Skpping:${songGemValue}
-            /call BardClass_CircularQueue_Pop
-            /varset songGemValue ${Macro.Return}
-            /call BardClass_CircularQueue_Insert "${songGemValue}"    
-        } else {
-          /break
-        }
-    }
-
   }
-  
+   /if (!${playingMelody} ) {
+    /echo issuing stopcast and kicking out
+    /stopcast
+    /return
+  } 
+  |Block in case we are currently casting a previous song
+   /while (${Window[CastingWindow].Open}) {
+		/doevents startMelody
+    /if (!${playingMelody}) {
+      /echo issuing stopcast and kicking out
+      /stopcast
+      /return
+    } 
+    /doevents Follow
+		/if (!${Window[CastingWindow].Open}) {
+		/break
+		}
+		/doevents Stop
+		/if (!${Window[CastingWindow].Open}) {
+		/break
+		}
+		/doevents MoveHere
+		/if (!${Window[CastingWindow].Open}) {
+		/break
+		}
+		/doevents BackOff
+		/if (!${Window[CastingWindow].Open}) {
+		/break
+		}
+		/doevents clickit
+		/if (!${Window[CastingWindow].Open}) {
+		/break
+		}
+		/doevents bark
+		/if (!${Window[CastingWindow].Open}) {
+		/break
+		}
+		/call alerts_Background_Events
+		/if (!${Window[CastingWindow].Open}) {
+		/break
+		}
+		/delay 1
+	}
+  |tap the current gem if we are casting 
+  /if (${Bool[${Me.Casting.ID}]} ) {
+    /delay 1
+    /stopcast
+  }
+  /if (!${playingMelody}) {
+    /echo issuing stopcast and kicking out
+    /stopcast
+    /return
+  } 
+  |don't try and cast if your are stunned
+  /while (${Me.Stunned}) {
+    /delay 1
+  }
+  |########
+  |Cast the Song/Item
   /if (${isItem}) {
+    |item isn't ready kickout
+    /if (!${Me.ItemReady[${songGemValue}]}) /return
     /echo [${Time}]: Twist-Click: "${songGemValue}"
     /useitem "${songGemValue}"
     /delay 1
-
+   
   } else {
-    /echo [${Time}]: Twist: "${songGemValue}"
+  
+    |is ths song ready? if not, kick out and loop back in
+    /if (${songGemValue.Equal[Verse of Vesagran]}) { 
+       /while (!${Me.SpellReady[${songGemValue}]}) {
+            |This is one of those *special* spells. Lets wait on its stupid cooldown
+            /delay 1
+         } 
+    }
+    
+    /if (!${Me.SpellReady[${songGemValue}]}) {
+      /echo [${Time}]: Twist-Skip: "${songGemValue}"
+      /return
+    } 
+    |cast the song
     /cast "${songGemValue}"
-    |need a delay of 3 to detect a missed song
+    /echo [${Time}]: Twist: "${songGemValue}"
     /delay 3
     /if (!${Window[CastingWindow].Open}) {
       /echo [${Time}]: fizzle happened, recasting
       /cast ${songGemValue}
-      /delay 1
+      /delay 3
     }
-    
   }
-  /while (${Window[CastingWindow].Open}) {
-    /doevents Follow
-    /if (!${Window[CastingWindow].Open}) {
-       /break
-     }
-    /doevents Stop
-    /if (!${Window[CastingWindow].Open}) {
-       /break
-     }
-    /doevents MoveHere
-    /if (!${Window[CastingWindow].Open}) {
-       /break
-     }
-    /doevents BackOff
-    /if (!${Window[CastingWindow].Open}) {
-       /break
-     }
-    /doevents clickit
-    /if (!${Window[CastingWindow].Open}) {
-       /break
-     }
-    /doevents bark
-    /if (!${Window[CastingWindow].Open}) {
-       /break
-     }
-    /call alerts_Background_Events
-    /if (!${Window[CastingWindow].Open}) {
-       /break
-     }
-    /delay 1
-  }
-  
-  
+  |End cast of song/item
+  |##############
 /return
 
 
@@ -283,7 +301,7 @@ SUB EVENT_startMelody(line, ChatSender, melodyName)
 
   |getting the melody name via c_eventArgs? odd 
   /if (!${checkEventArgs[${ChatSender},${line},UZR,${melodyName}]}) /return
-  /varset currentMelody ${melodyName}
+ 
 
   /varset melodyName ${c_eventArgData}
   /declare memGem int local
@@ -295,15 +313,19 @@ SUB EVENT_startMelody(line, ChatSender, melodyName)
     /if (${Select[${melodyName},Stop,End]}) {
       |empty out the queue
       /call BardClass_CircularQueue_Empty
-
+      /echo setting playingMelody FALSE
       /varset playingMelody FALSE
-      |**/varset songSet
-      /docommand ${ChatToggle} Ending melody.
-      /twist stop
-      |let gems reset
-      /delay 3
-      /echo setting fixedMelody to off**|
+      /varset fixedMelody off
 
+      /if (${songPlayer.Equal["MQ2Twist"]}) {
+          /varset songSet
+          /docommand ${ChatToggle} Ending melody.
+          /twist stop
+          |let gems reset
+          /delay 3
+      }
+     
+      
       /varset fixedMelody off
 
     } else /if (${Select[${melodyName},Pause]}) { 
@@ -328,7 +350,7 @@ SUB EVENT_startMelody(line, ChatSender, melodyName)
         /varset playingMelody FALSE
         /docommand ${ChatToggle} [${melodyName}] is not a known melody.
     } else {
-
+          /varset currentMelody ${melodyName}
           /varset fixedMelody ${melodyName}
           /declare spellName string local
           /declare i int local
@@ -344,8 +366,11 @@ SUB EVENT_startMelody(line, ChatSender, melodyName)
                 /call argueString gem| "${melodyArray[${i}]}"
                 /echo Found item for twist ${spellName}, will use item slot ${c_argueString}
                 /varset songList ${songList} ${c_argueString}
-                |/call BardClass_CircularQueue_Insert ${c_argueString}
-                /call BardClass_CircularQueue_Insert  "${spellName}"
+                /if (${songPlayer.Equal["Twist"]}) {
+                     /call BardClass_CircularQueue_Insert  "${spellName}"
+                } else {
+                    /call BardClass_CircularQueue_Insert ${c_argueString}
+                }
               } else {
                 | If the song is not memmed, use mq2Cast to mem
                 /if (!${Me.Gem[${spellName}]}) {
@@ -360,8 +385,12 @@ SUB EVENT_startMelody(line, ChatSender, melodyName)
                 } 
                 | Update songList with the corresponding gem#
                  /varset songList ${songList} ${Me.Gem[${spellName}]}
-                |/call BardClass_CircularQueue_Insert  "${Me.Gem[${spellName}]}"
-                /call BardClass_CircularQueue_Insert  "${spellName}"
+                /if (${songPlayer.Equal["Twist"]}) {
+                    /call BardClass_CircularQueue_Insert  "${spellName}"
+                } else {
+                    /call BardClass_CircularQueue_Insert  "${Me.Gem[${spellName}]}"
+                }
+                
               }
             }
           /next i
@@ -374,9 +403,13 @@ SUB EVENT_startMelody(line, ChatSender, melodyName)
             /varset songSet ${songList}
             |/echo singing Songset: ${songList}
             /docommand ${ChatToggle} Playing New Melody: [${melodyName}].
-          
-            |**/if (${songPlayer.NotEqual["Dynamo"]}) /twist ${songSet}**|
+            /if (${songPlayer.Equal["MQ2Twist"]}) {
+                /twist ${songSet}
+            }
+           
           }
+
+          /call BardClass_CircularQueue_PrintQueue
         }
     }
 
@@ -394,39 +427,38 @@ SUB pauseTwist
 /if (${Debug} || ${Debug_Casting}) /echo |- pauseTwist ==>
 	
   /varset playingMelody FALSE
-  /varset	returnTwist TRUE
-  /return
- 	
-  | just stop the quest and reorganize the playlist
+ 
+   /if (!${songPlayer.Equal["MQ2Twist"]}) {
+      /return
+   }
+  
+    /varset songSet
+    /docommand ${ChatToggle} Pausing: ${fixedMelody}.
+    /twist stop
+    |let gems reset
+    /delay 3
+    
+    /declare counter int local 0
+    /declare songGemValue string local
 
-      /varset playingMelody FALSE
-      /varset songSet
-      /docommand ${ChatToggle} Pausing: ${fixedMelody}.
-      /twist stop
-      |let gems reset
-      /delay 3
-      
-      /declare counter int local 0
-      /declare songGemValue string local
+    |loop through the current queue, poping off at the front, and reinserting back at the end
+    /while (${counter}< ${bardSongArrayQueueCount}) {
+      /call BardClass_CircularQueue_Peek
+      /varset songGemValue ${Macro.Return}
+      |found the variable that equals the last gem played
+      /if (!${songGemValue.Equal[${previousSpellGemThatWasCast}]}) {
 
-      |loop through the current queue, poping off at the front, and reinserting back at the end
-      /while (${counter}< ${bardSongArrayQueueCount}) {
-        /call BardClass_CircularQueue_Peek
-        /varset songGemValue ${Macro.Return}
-        |found the variable that equals the last gem played
-        /if (!${songGemValue.Equal[${previousSpellGemThatWasCast}]}) {
+            /call BardClass_CircularQueue_Pop
+            /varset songGemValue ${Macro.Return}
+            /call BardClass_CircularQueue_Insert "${songGemValue}"
 
-              /call BardClass_CircularQueue_Pop
-              /varset songGemValue ${Macro.Return}
-              /call BardClass_CircularQueue_Insert "${songGemValue}"
+      } else {
 
-        } else {
-
-          |it equals so kick out we are done
-          /break
-        } 
-        /varcalc counter ${counter}+1
-      }      
+        |it equals so kick out we are done
+        /break
+      } 
+      /varcalc counter ${counter}+1
+    }      
   
   
 /if (${Debug} || ${Debug_Casting}) /echo <== pauseTwist -|
@@ -434,8 +466,13 @@ SUB pauseTwist
 |--------------------------------------------------------------|
 --------------------------------------------------------------|
 SUB unpauseTwist
-  /varset playingMelody TRUE
-  /return
+  
+ 
+  /if (!${songPlayer.Equal["MQ2Twist"]}) {
+      /varset playingMelody TRUE
+      /return
+   }
+  
 	/delay 3s !${Me.Casting.ID}
 	
   /if (!${Bool[${playingMelody}]}) {
@@ -598,10 +635,15 @@ sub check_bard_mez
 
 | Change melodies based on MelodyIf statements
 SUB melodyIfs
+
   /if (!${playingMelody}) /return
+
   | when fixedMelody is stop, stop all melodies and don't let them start
   | when fixedMelody is off/null, start up MelodyIf again
   /if (!${Bool[${fixedMelody.Equal[off]}]} && !${currentMelody.Equal[${fixedMelody}]}) {
+    
+    /echo if starting up melody ${fixedMelody}
+
     /call EVENT_startMelody "<${Me}> melody ${fixedMelody}" "${Me}" "${fixedMelody}"
     /return
   } else /if (${currentMelody.Equal[${fixedMelody}]}) {
@@ -615,6 +657,9 @@ SUB melodyIfs
   /for i 1 to ${melodyIfs.Size[1]}
     /varset newIfMelody ${melodyIfs[${i},1]}
     /if (!${currentMelody.Equal[${newIfMelody}]} && (${melodyIfs[${i},2]})) {
+       
+      /echo if starting up melody:${newIfMelody}
+
       /call EVENT_startMelody "<${Me}> melody ${newIfMelody}" "${Me}" "${newIfMelody}"
     }
   /next i
@@ -711,9 +756,10 @@ Sub BRD_Background_Events
   /doevents charmOn
   /doevents charmOff
   /doevents setFixedMelody
-  /call melodyIfs
   /call autoSonata
   /call check_Dynamo
+  /call check_BardSongs
+  /call melodyIfs
 /return
 |--------------------------------------------------------------|
 SUB BRD_MacroSettings

--- a/Macros/e3 Includes/e3_Classes_Bard.inc
+++ b/Macros/e3 Includes/e3_Classes_Bard.inc
@@ -88,6 +88,7 @@ Sub BardClass_CircularQueue_PrintQueue
 /return
 
 
+
 Sub BardClass_CircularQueue_ToString
   /if (${bardSongArrayQueueCount}==0) {
     /echo BardClass Queue Empty Already
@@ -109,6 +110,119 @@ Sub BardClass_CircularQueue_ToString
 |----------------------------------------------------------------------------|
 | Bard Functions
 |----------------------------------------------------------------------------|
+
+sub check_BardSongs
+
+  /if (!${playingMelody}) /return
+  /if (${bardSongArrayQueueCount}==0) {
+    /return
+  }
+  /if (${Window[CastingWindow].Open}) {
+    /return
+  }
+  /if (${Bool[${Me.Casting.ID}]} ) {
+    |turn off our current song so we can start a new one
+     /cast ${Me.Gem[${Me.Casting}]}
+     |/delay 1
+  }
+  |we are not  casting, cast the next spell in the list. 
+  /call BardClass_CircularQueue_Pop
+  /declare songGemValue string local
+  /varset songGemValue ${Macro.Return}
+  /call BardClass_CircularQueue_Insert "${songGemValue}"
+  
+  |/if (${Me.Gem[${songGemValue}].Name.Equal[Selo's Accelerating Chorus]}) {
+   /if (${songGemValue.Equal[Selo's Accelerating Chorus]}) {
+    /if (${Me.Buff[Selo's Accelerating Chorus].Duration.TotalSeconds}>45) {
+      |we already have the buff up and it has > 45 seconds left, skip it
+      |/echo Skipping Selo's Accelerating Chorus as it has time left
+      /call BardClass_CircularQueue_Pop
+      /varset songGemValue ${Macro.Return}
+      /call BardClass_CircularQueue_Insert "${songGemValue}"      
+    }
+  }
+    
+  |/call castSimpleSpell "${Me.Gem[${songGemValue}]}" 0
+  |/declare castTime int local ${Spell[${Me.Gem[${songGemValue}]}].MyCastTime}
+
+
+  /if (${Bool[${FindItem[${songGemValue}]}]}) {
+    /declare castTime int local ${FindItem[${songGemValue}].CastTime}
+  } else {
+    /declare castTime int local ${Spell[${songGemValue}].MyCastTime}
+    
+  }
+  
+  /if (${castTime}<100) {
+    /varset castTime 100
+  }
+  /declare delayTime int local ${Math.Calc[${castTime}/100]}
+  
+  /varcalc delayTime ${delayTime} 
+
+  /if (${delayTime}<5) {
+    /varset delayTime 5
+  }
+  /if (${Bool[${FindItem[${songGemValue}]}]}) {
+    /useitem "${songGemValue}"
+   
+  } else {
+    /cast "${songGemValue}"
+    /delay 3 ${Window[CastingWindow].Open}
+    /delay 5
+    /if (!${Window[CastingWindow].Open}) {
+      /echo fizzle happened, recasting
+      /cast ${songGemValue}
+      /varcalc delayTime ${Math.Calc[${castTime}/100]}
+      /delay 5
+    }
+    
+  }
+  
+  
+  |/echo [${Time}]: ${Me.Gem[${songGemValue}]} | ${delayTime}
+  |/echo [${Time}]: ${songGemValue} | ${delayTime}
+
+  /while (${delayTime}>0) {
+     /if (!${Window[CastingWindow].Open}) {
+       /break
+     }
+    /doevents Follow
+    /if (!${Window[CastingWindow].Open}) {
+       /break
+     }
+    /doevents Stop
+    /if (!${Window[CastingWindow].Open}) {
+       /break
+     }
+    /doevents MoveHere
+    /if (!${Window[CastingWindow].Open}) {
+       /break
+     }
+    /doevents BackOff
+    /if (!${Window[CastingWindow].Open}) {
+       /break
+     }
+    /doevents clickit
+    /if (!${Window[CastingWindow].Open}) {
+       /break
+     }
+    /doevents bark
+    /if (!${Window[CastingWindow].Open}) {
+       /break
+     }
+    /call alerts_Background_Events
+    /if (!${Window[CastingWindow].Open}) {
+       /break
+     }
+    /delay 1
+    /varcalc delayTime ${delayTime} -1
+  }
+  |/delay ${delayTime}
+  
+/return
+
+
 #event saveMelody "<#1#> Save Melody #2# #3#"
 #event saveMelody "[MQ2] Save Melody #2# #3#"
 SUB EVENT_saveMelody(line, ChatSender, melodyName, songsToSave)
@@ -171,12 +285,13 @@ SUB EVENT_startMelody(line, ChatSender, melodyName)
       /call BardClass_CircularQueue_Empty
 
       /varset playingMelody FALSE
-      /varset songSet
+      |**/varset songSet
       /docommand ${ChatToggle} Ending melody.
       /twist stop
       |let gems reset
       /delay 3
-      /echo setting fixedMelody to off
+      /echo setting fixedMelody to off**|
+
       /varset fixedMelody off
 
     } else /if (${Select[${melodyName},Pause]}) { 
@@ -198,6 +313,7 @@ SUB EVENT_startMelody(line, ChatSender, melodyName)
     
     /call IniToArrayV "${Character_Ini},${melodyName} Melody,Song#" melodyArray
     /if (!${Defined[melodyArray]}) {
+        /varset playingMelody FALSE
         /docommand ${ChatToggle} [${melodyName}] is not a known melody.
     } else {
 
@@ -216,7 +332,8 @@ SUB EVENT_startMelody(line, ChatSender, melodyName)
                 /call argueString gem| "${melodyArray[${i}]}"
                 /echo Found item for twist ${spellName}, will use item slot ${c_argueString}
                 /varset songList ${songList} ${c_argueString}
-                /call BardClass_CircularQueue_Insert ${c_argueString}
+                |/call BardClass_CircularQueue_Insert ${c_argueString}
+                /call BardClass_CircularQueue_Insert  "${spellName}"
               } else {
                 | If the song is not memmed, use mq2Cast to mem
                 /if (!${Me.Gem[${spellName}]}) {
@@ -230,8 +347,9 @@ SUB EVENT_startMelody(line, ChatSender, melodyName)
                   /if (${Cast.Status.Find[M]}) /delay 3s !${Cast.Status.Find[M]}
                 } 
                 | Update songList with the corresponding gem#
-                /varset songList ${songList} ${Me.Gem[${spellName}]}
-                /call BardClass_CircularQueue_Insert  "${Me.Gem[${spellName}]}"
+                 /varset songList ${songList} ${Me.Gem[${spellName}]}
+                |/call BardClass_CircularQueue_Insert  "${Me.Gem[${spellName}]}"
+                /call BardClass_CircularQueue_Insert  "${spellName}"
               }
             }
           /next i
@@ -245,7 +363,7 @@ SUB EVENT_startMelody(line, ChatSender, melodyName)
             |/echo singing Songset: ${songList}
             /docommand ${ChatToggle} Playing New Melody: [${melodyName}].
           
-            /if (${songPlayer.NotEqual["Dynamo"]}) /twist ${songSet}
+            |**/if (${songPlayer.NotEqual["Dynamo"]}) /twist ${songSet}**|
           }
         }
     }
@@ -262,7 +380,10 @@ SUB EVENT_startMelody(line, ChatSender, melodyName)
 |--------------------------------------------------------------|
 SUB pauseTwist
 /if (${Debug} || ${Debug_Casting}) /echo |- pauseTwist ==>
-	/varset	returnTwist TRUE
+	
+  /varset playingMelody FALSE
+  /return
+  /varset	returnTwist TRUE
 	
   | just stop the quest and reorganize the playlist
 
@@ -301,6 +422,8 @@ SUB pauseTwist
 |--------------------------------------------------------------|
 --------------------------------------------------------------|
 SUB unpauseTwist
+  /varset playingMelody TRUE
+  /return
 	/delay 3s !${Me.Casting.ID}
 	
   /if (!${Bool[${playingMelody}]}) {

--- a/Macros/e3 Includes/e3_Classes_Bard.inc
+++ b/Macros/e3 Includes/e3_Classes_Bard.inc
@@ -111,11 +111,15 @@ Sub BardClass_CircularQueue_ToString
 | Bard Functions
 |----------------------------------------------------------------------------|
 
+
 sub check_BardSongs
   
   /if (!${songPlayer.Equal["Twist"]} || ${Me.Invis} || ${Me.Stunned}) {
       /return
   }
+  /declare didKick bool local false
+  
+
   |don't do songs when looting
   /if (${Target.CleanName.Equal[${Me}'s corpse]}) { 
       /return 
@@ -127,12 +131,18 @@ sub check_BardSongs
       /stopcast
     } 
     /return
-  }   
+  } 
+
+ 
+
   /if (!${playingMelody}) /return
   
   /if (${bardSongArrayQueueCount}==0) {
     /return
   }
+  
+  /call ActivateSelosKick
+
   |######################################################
   |Figure out the next song on the list to play
   /call BardClass_CircularQueue_Pop
@@ -158,49 +168,10 @@ sub check_BardSongs
   /if (${Bool[${FindItem[${songGemValue}]}]}) {
       /varset isItem True
   }
-   /if (!${playingMelody} ) {
-    /echo issuing stopcast and kicking out
-    /stopcast
-    /return
-  } 
-  |Block in case we are currently casting a previous song
-   /while (${Window[CastingWindow].Open}) {
-		/doevents startMelody
-    /if (!${playingMelody}) {
-      /echo issuing stopcast and kicking out
-      /stopcast
-      /return
-    } 
-    /doevents Follow
-		/if (!${Window[CastingWindow].Open}) {
-		/break
-		}
-		/doevents Stop
-		/if (!${Window[CastingWindow].Open}) {
-		/break
-		}
-		/doevents MoveHere
-		/if (!${Window[CastingWindow].Open}) {
-		/break
-		}
-		/doevents BackOff
-		/if (!${Window[CastingWindow].Open}) {
-		/break
-		}
-		/doevents clickit
-		/if (!${Window[CastingWindow].Open}) {
-		/break
-		}
-		/doevents bark
-		/if (!${Window[CastingWindow].Open}) {
-		/break
-		}
-		/call alerts_Background_Events
-		/if (!${Window[CastingWindow].Open}) {
-		/break
-		}
-		/delay 1
-	}
+  
+  /call ActivateSelosKick
+  /call BardSongWaitLockPumpQueue
+
   |tap the current gem if we are casting 
   /if (${Bool[${Me.Casting.ID}]} ) {
     /delay 1
@@ -233,7 +204,10 @@ sub check_BardSongs
             /delay 1
          } 
     }
-    
+    |a delay check, for sync 
+    /if (!${Me.SpellReady[${songGemValue}]}) {
+       /delay 1
+    } 
     /if (!${Me.SpellReady[${songGemValue}]}) {
       /echo [${Time}]: Twist-Skip: "${songGemValue}"
       /return
@@ -464,7 +438,8 @@ SUB pauseTwist
 /if (${Debug} || ${Debug_Casting}) /echo <== pauseTwist -|
 /return
 |--------------------------------------------------------------|
---------------------------------------------------------------|
+|--------------------------------------------------------------|
+
 SUB unpauseTwist
   
  
@@ -969,4 +944,63 @@ SUB delaySongCast(songName, myNhtTimerName)
     /if (${${myNhtTimerName}.OriginalValue} < 600) /varset ${myNhtTimerName} ${Math.Calc[${${myNhtTimerName}.OriginalValue} + 60]}
   }
   |/echo ${songName} did not take hold, waiting ${myNhtTimerName} = ${${myNhtTimerName}.OriginalValue} before trying again
+/RETURN
+
+sub ActivateSelosKick
+
+  /if (${Target.ID} && ${Target.ID} == ${AssistTarget} && ${Me.AltAbilityReady[Selo's Kick]}  && ${Spawn[${Target}].Distance} < 25 ) {
+
+    /alt activate 8205
+    /delay 5 !${Me.AltAbilityReady[Selo's Kick]}
+   
+  }
+
+/RETURN
+sub BardSongWaitLockPumpQueue
+  /if (!${playingMelody} ) {
+    /echo issuing stopcast and kicking out
+    /stopcast
+    /return
+  } 
+|Block in case we are currently casting a previous song
+  /while (${Window[CastingWindow].Open}) {
+  /doevents startMelody
+  /if (!${playingMelody}) {
+    /echo issuing stopcast and kicking out
+    /stopcast
+    /return
+  }
+  /call ActivateSelosKick
+
+  /doevents Follow
+  /if (!${Window[CastingWindow].Open}) {
+  /break
+  }
+  /doevents Stop
+  /if (!${Window[CastingWindow].Open}) {
+  /break
+  }
+  /doevents MoveHere
+  /if (!${Window[CastingWindow].Open}) {
+  /break
+  }
+  /doevents BackOff
+  /if (!${Window[CastingWindow].Open}) {
+  /break
+  }
+  /doevents clickit
+  /if (!${Window[CastingWindow].Open}) {
+  /break
+  }
+  /doevents bark
+  /if (!${Window[CastingWindow].Open}) {
+  /break
+  }
+  /call alerts_Background_Events
+  /if (!${Window[CastingWindow].Open}) {
+  /break
+  }
+  /delay 1
+}
+
 /RETURN

--- a/Macros/e3 Includes/e3_Classes_Beastlord.inc
+++ b/Macros/e3 Includes/e3_Classes_Beastlord.inc
@@ -54,12 +54,8 @@ Sub event_AE_POS(string line)
 	/if (${Me.Class.ShortName.Equal[BST]}) {
 		/if (${Me.AltAbilityReady[Mass Group Buff]} && ${Me.AltAbilityReady[Paragon of Spirit]}) {
 			/bc MGB Paragon of Spirit inc...
-			/casting "Mass Group Buff|alt" -maxtries|3
-			/delay 5 !${Me.AltAbilityReady[Mass Group Buff]}
-			/delay 5
-			/casting "Paragon of Spirit|alt" -maxtries|3
-			/delay 5 !${Me.AltAbilityReady[Paragon of Spirit]}
-			/casting "Paragon of Spirit|alt" -maxtries|3
+			/call castSimpleSpell "Mass Group Buff" 0
+			/call castSimpleSpell "Paragon of Spirit" 0
 			/rs MGB Paragon of Spirit inc...
 		} else /if (!${Me.AltAbilityReady[Mass Group Buff]}) {
 			/bc Mass Group Buff is not available...

--- a/Macros/e3 Includes/e3_Classes_Cleric.inc
+++ b/Macros/e3 Includes/e3_Classes_Cleric.inc
@@ -609,7 +609,7 @@ sub event_playerHammer(line, ChatSender)
 	  /if (${Bool[${FindItem[=Hammer of Damnation]}]}) {
         /ItemNotify "Hammer of Damnation" leftmouseup
       } else {
-		/call castSimpleSpell "Hammer of Damnation" 0
+		  /call castSimpleSpell "Hammer of Damnation" 0
 	  }
       /delay 6s ${Cursor.ID}
       /click left target

--- a/Macros/e3 Includes/e3_Classes_Cleric.inc
+++ b/Macros/e3 Includes/e3_Classes_Cleric.inc
@@ -6,7 +6,7 @@ SUB event_manastone
 /if (${Me.Sitting}) {
   		/sit off
 		}
-	/casting "Holy Elixir" "-targetid|${Me.ID}"
+  /call castSimpleSpell "Holy Elixir" ${Me.ID}
 	:Loop
 	/if (${Me.PctMana} < 100) {
 			/casting "Manastone"
@@ -16,11 +16,11 @@ SUB event_manastone
 |----------------------------------------------------------------------------|
 SUB check_Yaulp
 /if (${Debug}) /echo |- check_clrYaulp ==>
-  /if (${AutoYaulp} && !${medBreak} && !${Me.Moving})  {
+  /if (${AutoYaulp} && !${medBreak} && !${Me.Moving} && !${Me.Invis}) {
     /declare castName string local ${yaulpSpell.Arg[1,/]}
     /if (!${Bool[${Me.Buff[${castName}]}]} && ${Me.PctMana} < 95 && ${Spell[${castName}].NewStacks}) {
       /if (${Target.ID}) /declare tempTarget int local ${Target.ID}
-      /casting "${castName}" -invis
+      /call castSimpleSpell "${castName}" 0
     }
   }
 /if (${Debug}) /echo <== check_clrYaulp -|
@@ -396,12 +396,8 @@ sub Event_AE_CR(string line)
 /if (${Me.Class.ShortName.Equal[CLR]}) {
    /if (${Me.AltAbilityReady[Mass Group Buff]} && ${Me.AltAbilityReady[Celestial Regeneration]}) {
      /bc MGB Celestial Regeneration inc...
-     /casting "Mass Group Buff|alt" -maxtries|3
-     /delay 5 !${Me.AltAbilityReady[Mass Group Buff]}
-     /delay 5
-     /casting "Celestial Regeneration|alt" -maxtries|3
-     /delay 5 !${Me.AltAbilityReady[Celestial Regeneration]}
-     /casting "Celestial Regeneration|alt" -maxtries|3
+     /call castSimpleSpell "Mass Group Buff" 0
+     /call castSimpleSpell "Celestial Regeneration" 0
      /rs MGB Celestial Regeneration inc...
    } else /if (!${Me.AltAbilityReady[Mass Group Buff]}) {
       /bc Mass Group Buff is not available...
@@ -414,12 +410,8 @@ sub Event_AE_HP(string line)
 /if (${Me.Class.ShortName.Equal[CLR]}) {
    /if (${Me.AltAbilityReady[Mass Group Buff]} && ${Bool[${Me.Book[Ancient: Gift of Aegolism]}]}) {
      /bc MGB Ancient: Gift of Aegolism inc...
-     /casting "Mass Group Buff|alt" "-maxtries|3"
-     /delay 5 !${Me.AltAbilityReady[Mass Group Buff]}
-     /delay 5
-     /casting "Ancient: Gift of Aegolism" "-maxtries|3"
-     /delay 5 !${Me.SpellReady[Ancient: Gift of Aegolism]}
-     /casting "Ancient: Gift of Aegolism" "-maxtries|3"
+     /call castSimpleSpell "Mass Group Buff" 0
+     /call castSimpleSpell "Ancient: Gift of Aegolism" 0
    } else /if (!${Me.AltAbilityReady[Mass Group Buff]}) {
       /bc Mass Group Buff is not available...
    } else /bc Ancient: Gift of Aegolism is not in your Spell Book noob...
@@ -617,7 +609,7 @@ sub event_playerHammer(line, ChatSender)
 	  /if (${Bool[${FindItem[=Hammer of Damnation]}]}) {
         /ItemNotify "Hammer of Damnation" leftmouseup
       } else {
-		/cast "Hammer of Damnation"
+		/call castSimpleSpell "Hammer of Damnation" 0
 	  }
       /delay 6s ${Cursor.ID}
       /click left target

--- a/Macros/e3 Includes/e3_Classes_Druid.inc
+++ b/Macros/e3 Includes/e3_Classes_Druid.inc
@@ -64,7 +64,9 @@ Sub DRU_Background_Events
 
 | Automatically cast group AA Communion of the Cheetah whenever the buff is missing on the Druid and the druid doesn't have Selo's Sonata
 SUB autoCheetah
-  /if (${autoCheetahOn} && !${Me.Buff[Selo's Sonata].ID} && (!${Me.Buff[Spirit of Cheetah].ID} || ${Me.Buff[Spirit of Cheetah].Duration.TotalSeconds} < 10) && !${Me.Invis} && ${Me.AltAbilityReady[Communion of the Cheetah]}) {
+
+
+  /if (${autoCheetahOn} && !${Me.Buff[Selo's Sonata].ID} && !${Me.Buff[Selo's Accelerating Chorus].ID} && (!${Me.Buff[Spirit of Cheetah].ID} || ${Me.Buff[Spirit of Cheetah].Duration.TotalSeconds} < 10) && !${Me.Invis} && ${Me.AltAbilityReady[Communion of the Cheetah]}) {
 	/alt act 939
   }
 /RETURN

--- a/Macros/e3 Includes/e3_Classes_Druid.inc
+++ b/Macros/e3 Includes/e3_Classes_Druid.inc
@@ -33,12 +33,8 @@ sub Event_AE_SOW(string line)
 	/if (${Me.Class.ShortName.Equal[DRU]}) {
 	 /if (${Me.AltAbilityReady[Mass Group Buff]} && ${Me.AltAbilityReady[Spirit of the Wood]}) {
 		 /bc MGB Spirit of the Wood inc...
-		 /casting "Mass Group Buff|alt" -maxtries|3
-		 /delay 5 !${Me.AltAbilityReady[Mass Group Buff]}
-		 /delay 5
-		 /casting "Spirit of the Wood|alt" -maxtries|3
-		 /delay 5 !${Me.AltAbilityReady[Spirit of the Wood]}
-		 /casting "Spirit of the Wood|alt" -maxtries|3
+		 /call castSimpleSpell "Mass Group Buff" 0
+		 /call castSimpleSpell "Spirit of the Wood" 0
 		 /rs MGB Spirit of the Wood inc...
 	 } else /if (!${Me.AltAbilityReady[Mass Group Buff]}) {
 			/bc Mass Group Buff is not available...
@@ -51,12 +47,8 @@ sub Event_AE_FOE(string line)
 	/if (${Me.Class.ShortName.Equal[DRU]}) {
 	 /if (${Me.AltAbilityReady[Mass Group Buff]} && ${Bool[${Me.Book[Flight of Eagles]}]}) {
 		 /bc MGB Flight of Eagles inc...
-		 /casting "Mass Group Buff|alt" -maxtries|3
-		 /delay 5 !${Me.AltAbilityReady[Mass Group Buff]}
-		 /delay 5
-		 /casting "Flight of Eagles" -maxtries|3
-		 /delay 5 !${Me.AltAbilityReady[Spirit of the Wood]}
-		 /casting "Flight of Eagles" -maxtries|3
+		 /call castSimpleSpell "Mass Group Buff" 0
+		 /call castSimpleSpell "Flight of Eagles" 0
 		 /rs MGB Spirit of the Wood inc...
 	 } else /if (!${Me.AltAbilityReady[Mass Group Buff]}) {
 			/bc Mass Group Buff is not available...
@@ -73,7 +65,6 @@ Sub DRU_Background_Events
 | Automatically cast group AA Communion of the Cheetah whenever the buff is missing on the Druid and the druid doesn't have Selo's Sonata
 SUB autoCheetah
   /if (${autoCheetahOn} && !${Me.Buff[Selo's Sonata].ID} && (!${Me.Buff[Spirit of Cheetah].ID} || ${Me.Buff[Spirit of Cheetah].Duration} < 10000) && !${Me.Invis} && ${Me.AltAbilityReady[Communion of the Cheetah]}) {
-    /call TrueTarget ${Me.ID}
 	/alt act 939
   }
 /RETURN

--- a/Macros/e3 Includes/e3_Classes_Druid.inc
+++ b/Macros/e3 Includes/e3_Classes_Druid.inc
@@ -64,7 +64,7 @@ Sub DRU_Background_Events
 
 | Automatically cast group AA Communion of the Cheetah whenever the buff is missing on the Druid and the druid doesn't have Selo's Sonata
 SUB autoCheetah
-  /if (${autoCheetahOn} && !${Me.Buff[Selo's Sonata].ID} && (!${Me.Buff[Spirit of Cheetah].ID} || ${Me.Buff[Spirit of Cheetah].Duration} < 10000) && !${Me.Invis} && ${Me.AltAbilityReady[Communion of the Cheetah]}) {
+  /if (${autoCheetahOn} && !${Me.Buff[Selo's Sonata].ID} && (!${Me.Buff[Spirit of Cheetah].ID} || ${Me.Buff[Spirit of Cheetah].Duration.TotalSeconds} < 10) && !${Me.Invis} && ${Me.AltAbilityReady[Communion of the Cheetah]}) {
 	/alt act 939
   }
 /RETURN

--- a/Macros/e3 Includes/e3_Classes_Enchanter.inc
+++ b/Macros/e3 Includes/e3_Classes_Enchanter.inc
@@ -283,7 +283,7 @@ Sub ENC_Background_Events
 	/doevents toggleRune
 	/doevents add_RuneTarget
 	/doevents remove_RuneTarget
-	/if (${Assisting} && ${Bool[${gatherManaPCT}]} && ${Me.PctMana} < ${gatherManaPCT} && ${Me.AltAbilityReady[Gather Mana]} && ${Me.CombatState.Equal[COMBAT]}) /casting "Gather Mana" -maxtries|3
+	/if (${Assisting} && ${Bool[${gatherManaPCT}]} && ${Me.PctMana} < ${gatherManaPCT} && ${Me.AltAbilityReady[Gather Mana]} && ${Me.CombatState.Equal[COMBAT]}) /call castSimpleSpell "Gather Mana" 0
 /return
 |----------------------------------------------------------------------------|
 SUB ENC_MacroSettings

--- a/Macros/e3 Includes/e3_Classes_Magician.inc
+++ b/Macros/e3 Includes/e3_Classes_Magician.inc
@@ -246,25 +246,18 @@ sub event_armPets(line, ChatSender, loadType)
 /return
 sub summonUnpackAndSelect(targetID, spellName, ItemName, primaryItem, secondaryItem)
 
-      /if (${Defined[armPetArray]}) /deletevar armPetArray
-      /declare armPetArray[1] string outer ${spellName}
-      /if (${armPetArray.Size}) {
-      
-        /call BuildSpellArray "armPetArray" "armPetArray2D"
-        /call e3_Cast ${Me.ID} "armPetArray2D" 1 False
-        /while (!${Select[${castReturn},CAST_SUCCESS]}) {
-             /call e3_Cast ${Me.ID} "armPetArray2D" 1 False
-        }
-        /if (${Defined[armPetArray]}) /deletevar armPetArray
-
-        /delay 1s
+     
+        /call castSimpleSpell "${spellName}" ${Me.ID}
+        /delay 3s ${Bool[${Cursor.ID}]}
         |/echo done casting, put in inventory
         /call ClearCursor
+        /delay 3s !${Bool[${Cursor.ID}]}
         /delay 1s
         |/echo unfolding the bag to cursor
         /ItemNotify "${ItemName}" rightmouseup
-        /delay 4s 
+        /delay 3s ${Bool[${Cursor.ID}]}
         /call ClearCursor
+        /delay 3s !${Bool[${Cursor.ID}]}
         /delay 1s
         /itemnotify "${primaryItem}" leftmouseup
         /delay 5s ${Bool[${Cursor.ID}]}
@@ -298,23 +291,16 @@ sub summonUnpackAndSelect(targetID, spellName, ItemName, primaryItem, secondaryI
             /echo summonUnpackAndSelect: Could not destroy bag, exiting
             /return
           }
-           /if (${Defined[armPetArray]}) /deletevar armPetArray
-          /declare armPetArray[1] string outer ${spellName}
-          /call BuildSpellArray "armPetArray" "armPetArray2D"
-          /call e3_Cast ${Me.ID} "armPetArray2D" 1 False
-          /while (!${Select[${castReturn},CAST_SUCCESS]}) {
-              /call e3_Cast ${Me.ID} "armPetArray2D" 1 False
-          }
-          /if (${Defined[armPetArray]}) /deletevar armPetArray
-          /delay 1s
+          /call castSimpleSpell "${spellName}" ${Me.ID}
+          /delay 3s ${Bool[${Cursor.ID}]}
           |/echo done casting, put in inventory
           /call ClearCursor
-          /delay 1s
+          /delay 3s !${Bool[${Cursor.ID}]}
           |/echo unfolding the bag to cursor
           /ItemNotify "${ItemName}" rightmouseup
-          /delay 4s 
+          /delay 3s ${Bool[${Cursor.ID}]}
           /call ClearCursor
-          /delay 1s
+          /delay 3s !${Bool[${Cursor.ID}]}
           /call TrueTarget ${targetID}
         } 
        
@@ -345,23 +331,14 @@ sub summonUnpackAndSelect(targetID, spellName, ItemName, primaryItem, secondaryI
           /return
         }
 
-      }
+      
 
 /return
 sub summonUnpackAndGive(targetID, spellName, ItemName)
 
-     /if (${Defined[armPetArray]}) /deletevar armPetArray
-      /declare armPetArray[1] string outer ${spellName}
-      /if (${armPetArray.Size}) {
-        |/echo building the spell array for heirlooms
-
-        /call BuildSpellArray "armPetArray" "armPetArray2D"
-        /call e3_Cast ${Me.ID} "armPetArray2D" 1 False
-        /while (!${Select[${castReturn},CAST_SUCCESS]}) {
-             /call e3_Cast ${Me.ID} "armPetArray2D" 1 False
-        }
-        
-         /if (${Defined[armPetArray]}) /deletevar armPetArray
+     
+        /call castSimpleSpell "${spellName}" ${Me.ID}
+        /delay 3s ${Bool[${Cursor.ID}]}
         /delay 1s
         |/echo done casting, put in inventory
         /autoinventory
@@ -369,7 +346,7 @@ sub summonUnpackAndGive(targetID, spellName, ItemName)
         /delay 1s
         |/echo unfolding the bag to cursor
         /ItemNotify "${ItemName}" rightmouseup
-        /delay 3s
+         /delay 3s ${Bool[${Cursor.ID}]}
         |/echo getting the target of the pet
         /call TrueTarget ${targetID}
         /if (${Target.ID} && ${Target.Distance}>19) /call MoveToLoc ${Target.Y} ${Target.X} 50 15
@@ -378,7 +355,7 @@ sub summonUnpackAndGive(targetID, spellName, ItemName)
           /echo summonUnpackAndGive: Something went wrong and something is on your cursor, exiting.
           /return
         }
-      }
+      
 
 /return
 sub giveItemOnCursorToTarget()

--- a/Macros/e3 Includes/e3_Classes_Magician.inc
+++ b/Macros/e3 Includes/e3_Classes_Magician.inc
@@ -710,7 +710,7 @@ SUB check_OrbOfMasteryCharges
     | if toon has no orb of mastery
     /if (!${Bool[${FindItem[=Orb of Mastery]}]}) {
       /docommand ${ChatToggle} No Orb of Mastery in inventory, summoning an Orb of Mastery
-      /casting "Summon Orb"
+      /call castSimpleSpell "Summon Orb" 0
       /delay 12s ${Cursor.ID}
       /while (${Cursor.ID}) {
         /autoinv

--- a/Macros/e3 Includes/e3_Classes_Necromancer.inc
+++ b/Macros/e3 Includes/e3_Classes_Necromancer.inc
@@ -65,12 +65,8 @@ sub Event_AE_DMF(string line)
 /if (${Me.Class.ShortName.Equal[NEC]}) {
    /if (${Me.AltAbilityReady[Mass Group Buff]} && ${Bool[${Me.Book[Dead Men Floating]}]}) {
      /bc MGB Dead Men Floating inc...
-     /casting "Mass Group Buff|alt" "-maxtries|3"
-     /delay 5 !${Me.AltAbilityReady[Mass Group Buff]}
-     /delay 5
-     /casting "Dead Men Floating" "-maxtries|3"
-     /delay 5 !${Me.SpellReady[Dead Men Floating]}
-     /casting "Dead Men Floating" "-maxtries|3"
+     /call castSimpleSpell "Mass Group Buff" 0
+     /call castSimpleSpell "Dead Men Floating" 0
      /rs MGB Dead Men Floating inc...
    } else /if (!${Me.AltAbilityReady[Mass Group Buff]}) {
       /bc Mass Group Buff is not available...

--- a/Macros/e3 Includes/e3_Classes_Ranger.inc
+++ b/Macros/e3 Includes/e3_Classes_Ranger.inc
@@ -34,11 +34,8 @@ sub Event_AE_AOH(string line)
   /if (${Me.Class.ShortName.Equal[RNG]}) {
    /if (${Me.AltAbilityReady[Mass Group Buff]} && ${Me.AltAbilityReady[Auspice of the Hunter]}) {
      /bc MGB Auspice of the Hunter inc...
-     /casting "Mass Group Buff|alt" -maxtries|3
-     /delay 5 !${Me.AltAbilityReady[Mass Group Buff]}
-     /delay 5
-     /delay 5 !${Me.AltAbilityReady[Auspice of the Hunter]}
-     /casting "Auspice of the Hunter|alt" -maxtries|3
+     /call castSimpleSpell "Mass Group Buff" 0
+     /call castSimpleSpell "Auspice of the Hunter" 0
      /rs MGB Auspice of the Hunter inc...
    } else /if (!${Me.AltAbilityReady[Mass Group Buff]}) {
       /bc Mass Group Buff is not available...

--- a/Macros/e3 Includes/e3_Classes_Shaman.inc
+++ b/Macros/e3 Includes/e3_Classes_Shaman.inc
@@ -65,12 +65,8 @@ sub Event_AE_AA(string line)
 	/if (${Me.Class.ShortName.Equal[SHM]}) {
    /if (${Me.AltAbilityReady[Mass Group Buff]} && ${Me.AltAbilityReady[Ancestral Aid]}) {
      /bc MGB Ancestral Aid inc...
-     /casting "Mass Group Buff|alt" -maxtries|3
-     /delay 5 !${Me.AltAbilityReady[Mass Group Buff]}
-     /delay 5
-     /casting "Ancestral Aid|alt" -maxtries|3
-     /delay 5 !${Me.AltAbilityReady[Ancestral Aid]}
-     /casting "Ancestral Aid|alt" -maxtries|3
+	 /call castSimpleSpell "Mass Group Buff" 0
+     /call castSimpleSpell "Ancestral Aid" 0
      /rs MGB Ancestral Aid inc...
    } else /if (!${Me.AltAbilityReady[Mass Group Buff]}) {
       /bc Mass Group Buff is not available...

--- a/Macros/e3 Includes/e3_Heals.inc
+++ b/Macros/e3 Includes/e3_Heals.inc
@@ -755,7 +755,7 @@ SUB check_HealCasting_DuringBurns
 |---------------------------------------------------------------------------|
 |- Used with heals spells to interrupt so that we can heal tanks/xtargets  -|
 |---------------------------------------------------------------------------|
-SUB check_TankAndXTargetNeedHeal
+SUB check_TankAndXTargetNeedHeal(ArrayName)
 
 	/declare currentBot string local NULL
 	/declare currentSpellIndx int local
@@ -765,12 +765,14 @@ SUB check_TankAndXTargetNeedHeal
 	/declare s int local	
 
 	/varset c_SubToRun TRUE
+	 /if (!${Select[${ArrayName},hotSpells2D]}) {
 
-	/if (${Spawn[id ${Target.ID}].PctHPs} > ${interruptHealPct}) {
-		/echo [${Time}]: check_TankAndXTargetNeedHeal target above threshold for heals, setting interrupt flag
-		/varset c_SubToRun FALSE
-		/return
-	}
+		/if (${Spawn[id ${Target.ID}].PctHPs} > ${interruptHealPct}) {
+			/echo [${Time}]: check_TankAndXTargetNeedHeal target above threshold for heals, setting interrupt flag
+			/varset c_SubToRun FALSE
+			/return
+		}
+	 }
 	/if (${healTanks}) {
 		|/echo check_HealTankCasting_DuringDetrimental checking tank heals
 		/for t 1 to ${tanks.Size}
@@ -831,7 +833,7 @@ SUB check_TankAndXTargetNeedHeal
 
 
 |---------------------------------------------------------------------------|
-|- Used with heals spells to interrupt so that we can heal tanks/xtargets  -|
+|- Used with heals spells to interrupt so that we can heal tanks		   -|
 |---------------------------------------------------------------------------|
 SUB check_TankNeedHeal
 

--- a/Macros/e3 Includes/e3_Heals.inc
+++ b/Macros/e3 Includes/e3_Heals.inc
@@ -471,6 +471,10 @@ SUB hot_pets
 |------------------------------------------------|
 SUB check_HotTankStack(targetName, spellID)
 	/varset c_SubToRun TRUE
+	/call check_TankAndXTargetNeedHeal
+	/if (!${c_SubToRun}) {
+		/return
+	}
 	/declare i int local
 	/if (!${Defined[targetName]}) {
 		/declare targShortBuff string local ${NetBots[${Target.CleanName}].ShortBuff.Replace[ ,,]}

--- a/Macros/e3 Includes/e3_Heals.inc
+++ b/Macros/e3 Includes/e3_Heals.inc
@@ -622,7 +622,6 @@ SUB check_HealCasting_DuringDetrimental
 	}
 
 	/if (${healXTargets}) {
-	|/if (false) {	
 		/if (${Math.Rand[2]}==0) {
 			/for xtargetIndex 1 to ${numXTargets}
 		} else {
@@ -655,6 +654,102 @@ SUB check_HealCasting_DuringDetrimental
 	}
 
 	|/echo check_HealCasting_DuringDetrimental no target found
+
+/RETURN
+
+
+|--------------------------------------------------|
+|- Used with determental spells to interrupt	  -|
+|--------------------------------------------------|
+SUB check_HealCasting_DuringBurns
+	/varset c_SubToRun TRUE
+	|/echo called check_HealTankCasting_DuringDetrimental
+	|First check the tank heals
+	/declare currentBot string local NULL
+	/declare currentSpellIndx int local
+	/declare xtargetIndex int local NULL
+	/declare numXTargets int local 13
+	/declare t int local
+	/declare s int local	
+
+	/if (${healTanks}) {
+		|/echo check_HealTankCasting_DuringDetrimental checking tank heals
+		/for t 1 to ${tanks.Size}
+			/for s 1 to ${tankHeals2D.Size[1]}
+				|/echo Tank HP ${NetBots[${tanks[${t}]}].PctHPs} vs configured ${tankHeals2D[${s},${iHealPct}]}
+				/if (${Bool[${NetBots[${tanks[${t}]}].InZone}]} && ${NetBots[${tanks[${t}]}].PctHPs} <= ${tankHeals2D[${s},${iHealPct}]}) {
+					|interrupt any determenal spell if casting if we are supposed to be healing		
+					/if (${check_Distance[${NetBots[${tanks[${t}]}].ID},${tankHeals2D[${s},${iMyRange}]}]}) {
+						
+						/varset currentBot ${tanks[${t}]}
+						/varset currentSpellIndx ${s}
+					}
+				}
+			/if (!${Bool[${currentBot}]}) /next s
+		/if (!${Bool[${currentBot}]}) /next t
+
+		/if (${Bool[${currentBot}]}) {
+		
+			/varset c_SubToRun FALSE
+			/RETURN
+		}	
+		
+	}
+
+	/if (${healImportant}) {
+		/for t 1 to ${importantBots.Size}
+			/for s 1 to ${importantHeals2D.Size[1]}
+				/if (${Bool[${NetBots[${importantBots[${t}]}].InZone}]} && ${NetBots[${importantBots[${t}]}].PctHPs} <= ${importantHeals2D[${s},${iHealPct}]}) {
+					/if (${importantHeals2D[${s},${iIfs}]}) {
+						/if (${check_Mana["importantHeals2D",${s}]}) {
+							/if (!${Bool[${currentBot}]} || ${NetBots[${importantBots[${t}]}].PctHPs} < ${NetBots[${currentBot}].PctHPs}) {
+							/varset currentBot ${importantBots[${t}]}
+							/varset currentSpellIndx ${s}
+							}
+						}
+					}
+				}
+			/next s
+		/next t
+		/if (${Bool[${currentBot}]}) {
+			/varset c_SubToRun FALSE
+			/RETURN
+		}
+
+	}
+
+	/if (${healXTargets}) {
+	
+		/if (${Math.Rand[2]}==0) {
+			/for xtargetIndex 1 to ${numXTargets}
+		} else {
+			/for xtargetIndex ${numXTargets} downto 1
+		}
+			/if (${Me.XTarget[${xtargetIndex}].TargetType.Equal[Specific PC]} ) {
+				/for s 1 to ${xtargetHeals2D.Size[1]}
+					/if (${Me.XTarget[${xtargetIndex}].PctHPs} < ${xtargetHeals2D[${s},${iHealPct}]}) {
+						/if (${xtargetHeals2D[${s},${iIfs}]}) {
+							/if (${check_Distance[${Me.XTarget[${xtargetIndex}].ID},${xtargetHeals2D[${s},${iMyRange}]}]}) {
+								/if (${check_Mana["xtargetHeals2D",${s}]}) {
+									/if (!${Bool[${currentBot}]} || ${Me.XTarget[${xtargetIndex}].PctHPs} < ${Me.XTarget[${currentBot}].PctHPs}) {
+										
+										/varset currentBot ${xtargetIndex}
+										/varset currentSpellIndx ${s}
+									}
+								}
+							}
+						}
+					}
+				/next s
+			}
+		/next xtargetIndex
+
+		/if (${Bool[${currentBot}]}) {
+				/varset c_SubToRun FALSE
+			/RETURN
+		}
+	}
+
 
 /RETURN
 |---------------------------------------------------------------------------|

--- a/Macros/e3 Includes/e3_Heals.inc
+++ b/Macros/e3 Includes/e3_Heals.inc
@@ -124,12 +124,11 @@ SUB heal_importantBots
   |/echo cb ${currentBot} ${Bool[${currentBot}]}
 	/if (${Bool[${currentBot}]}) {
 
-		/varset importantHeals2D[${currentSpellIndx},${iSubToRun}] check_TankAndXTargetNeedHeal
+		/varset importantHeals2D[${currentSpellIndx},${iSubToRun}] check_TankNeedHeal
 		|-Our cast may have been interrupted so need to do a quick check on heals
 		/call e3_Cast ${NetBots[${currentBot}].ID} "importantHeals2D" ${currentSpellIndx}
 		/if (${castReturn.Equal[CAST_INTERRUPTED]}) {
 			/call heal_tanks
-			/call heal_xtargets
 		}
 	}
 /if (${Debug} || ${Debug_Heals}) /echo <== heal_importantBots -|
@@ -314,7 +313,7 @@ SUB hot_tanks
 	
 	/if (${Bool[${currentBot}]}) {
 
-		/varset hotSpells2D[${currentSpellIndx},${iSubToRun}] check_HotTankStack
+		/varset hotSpells2D[${currentSpellIndx},${iSubToRun}] check_TankAndXTargetNeedHeal
 		/call e3_Cast ${NetBots[${currentBot}].ID} "hotSpells2D" ${currentSpellIndx}
 
 		|-Our cast may have been interrupted so need to do a quick check on heals
@@ -358,7 +357,7 @@ SUB hot_importantBots
   /next t
 
   /if (${Bool[${currentBot}]}) {
-    /varset hotSpells2D[${currentSpellIndx},${iSubToRun}] check_HotImportantBotStack
+    /varset hotSpells2D[${currentSpellIndx},${iSubToRun}] check_TankAndXTargetNeedHeal
     /call e3_Cast ${NetBots[${currentBot}].ID} "hotSpells2D" ${currentSpellIndx}
 	|-Our cast may have been interrupted so need to do a quick check on heals
 	/if (${castReturn.Equal[CAST_INTERRUPTED]}) {
@@ -408,7 +407,7 @@ SUB hot_Allbots
 	/next t
 	
 	/if (${Bool[${currentBot}]}) {
-		/varset hotSpells2D[${currentSpellIndx},${iSubToRun}] check_HotAllStack
+		/varset hotSpells2D[${currentSpellIndx},${iSubToRun}] check_TankAndXTargetNeedHeal
 		/call e3_Cast ${NetBots[${currentBot}].ID} "hotSpells2D" ${currentSpellIndx}
 |		/call set_RecentHealTimer "${hotSpells2D[${s},${iCastType}]}"
 		/if (${castReturn.Equal[CAST_INTERRUPTED]}) {
@@ -453,7 +452,7 @@ SUB hot_pets
   /next t
   |/echo ${currentBot} ${Spawn[pc =${currentBot}].Pet.ID} ${Spawn[pc =${currentBot}].Pet.Name}
   /if (${Bool[${currentBot}]}) {
-    /varset hotSpells2D[${currentSpellIndx},${iSubToRun}] check_HotPetStack
+    /varset hotSpells2D[${currentSpellIndx},${iSubToRun}] check_TankAndXTargetNeedHeal
     /call e3_Cast ${NetBots[${currentBot}].PetID} "hotSpells2D" ${currentSpellIndx}
 
 	|-Our cast may have been interrupted so need to do a quick check on heals
@@ -471,10 +470,7 @@ SUB hot_pets
 |------------------------------------------------|
 SUB check_HotTankStack(targetName, spellID)
 	/varset c_SubToRun TRUE
-	/call check_TankAndXTargetNeedHeal
-	/if (!${c_SubToRun}) {
-		/return
-	}
+	
 	/declare i int local
 	/if (!${Defined[targetName]}) {
 		/declare targShortBuff string local ${NetBots[${Target.CleanName}].ShortBuff.Replace[ ,,]}
@@ -495,13 +491,6 @@ SUB check_HotTankStack(targetName, spellID)
 |------------------------------------------------|
 SUB check_HotImportantBotStack(targetName, spellID)
 	/varset c_SubToRun TRUE
-
-	
-	/call check_TankAndXTargetNeedHeal
-	/if (!${c_SubToRun}) {
-		/return
-	}
-
 	/declare i int local
 	/if (!${Defined[targetName]}) {
 		/declare targShortBuff string local ${NetBots[${Target.CleanName}].ShortBuff.Replace[ ,,]}
@@ -522,11 +511,6 @@ SUB check_HotImportantBotStack(targetName, spellID)
 |------------------------------------------------|
 SUB check_HotAllStack(targetName, spellID)
 	/varset c_SubToRun TRUE
-
-	/call check_TankAndXTargetNeedHeal
-	/if (!${c_SubToRun}) {
-		/return
-	}
 
 	/declare i int local
 	/if (!${Defined[targetName]}) {
@@ -549,11 +533,6 @@ SUB check_HotAllStack(targetName, spellID)
 SUB check_HotPetStack(targetName, spellID)
   /varset c_SubToRun TRUE
 
-	/call check_TankAndXTargetNeedHeal
-	/if (!${c_SubToRun}) {
-		/return
-	}
-
   /declare i int local
   /if (!${Defined[targetName]}) {
     /declare targShortBuff string local ${NetBots[${Target.CleanName}].PetBuff.Replace[ ,,]}
@@ -574,9 +553,11 @@ SUB check_HotPetStack(targetName, spellID)
 |- Checks while casting tank heals		-|
 |----------------------------------------|
 SUB check_HealTankCasting
-	/varset c_SubToRun FALSE
-	/if (${castEndTime} > ${interruptTankCastSec} || ${Spawn[id ${Target.ID}].PctHPs} < ${interruptHealPct}) /varset c_SubToRun TRUE
-  |/echo cth ${Target.CleanName} nb ${NetBots[${Target.CleanName}].PctHPs} s ${Spawn[${Target.CleanName}].PctHPs} cet ${castEndTime} ${passCheck} ${interruptTankCastSec}
+	/varset c_SubToRun TRUE
+	/if (${Spawn[id ${Target.ID}].PctHPs} > ${interruptHealPct}) {
+		/echo [${Time}]: check_HealTankCasting target above threshold for heals, setting interrupt flag
+		/varset c_SubToRun FALSE
+	}
 /RETURN
 
 |--------------------------------------------------|
@@ -610,7 +591,7 @@ SUB check_HealCasting_DuringDetrimental
 		/if (!${Bool[${currentBot}]}) /next t
 
 		/if (${Bool[${currentBot}]}) {
-			/echo check_HealCasting_DuringDetrimental tank setting interrupt flag
+			/echo [${Time}]: check_HealCasting_DuringDetrimental tank setting interrupt flag
 			/varset c_SubToRun FALSE
 			/RETURN
 		}	
@@ -633,7 +614,7 @@ SUB check_HealCasting_DuringDetrimental
 			/next s
 		/next t
 		/if (${Bool[${currentBot}]}) {
-			/echo check_HealCasting_DuringDetrimental important bot setting interrupt flag
+			/echo [${Time}]: check_HealCasting_DuringDetrimental important bot setting interrupt flag
 			/varset c_SubToRun FALSE
 			/RETURN
 		}
@@ -667,7 +648,7 @@ SUB check_HealCasting_DuringDetrimental
 		/next xtargetIndex
 
 		/if (${Bool[${currentBot}]}) {
-			/echo check_HealCasting_DuringDetrimental xtarget setting interrupt flag
+			/echo [${Time}]: check_HealCasting_DuringDetrimental xtarget setting interrupt flag
 			/varset c_SubToRun FALSE
 			/RETURN
 		}
@@ -689,6 +670,12 @@ SUB check_TankAndXTargetNeedHeal
 	/declare s int local	
 
 	/varset c_SubToRun TRUE
+
+	/if (${Spawn[id ${Target.ID}].PctHPs} > ${interruptHealPct}) {
+		/echo [${Time}]: check_TankAndXTargetNeedHeal target above threshold for heals, setting interrupt flag
+		/varset c_SubToRun FALSE
+		/return
+	}
 	/if (${healTanks}) {
 		|/echo check_HealTankCasting_DuringDetrimental checking tank heals
 		/for t 1 to ${tanks.Size}
@@ -700,15 +687,16 @@ SUB check_TankAndXTargetNeedHeal
 						
 						/varset currentBot ${tanks[${t}]}
 						/varset currentSpellIndx ${s}
+						/goto :endTankCheck
 					}
 				}
-			/if (!${Bool[${currentBot}]}) /next s
-		/if (!${Bool[${currentBot}]}) /next t
-
+			/next s
+		/next t
+		:endTankCheck
 		/if (${Bool[${currentBot}]}) {
-			/echo check_TankAndXTargetNeedHeal tank needs heal setting interrupt flag
+			/echo [${Time}]: check_TankAndXTargetNeedHeal tank needs heal setting interrupt flag
 			/varset c_SubToRun FALSE
-			/RETURN
+			/return
 		}	
 		|/echo check_HealCasting_DuringDetrimental no target found
 	}
@@ -739,39 +727,99 @@ SUB check_TankAndXTargetNeedHeal
 		/next xtargetIndex
 
 		/if (${Bool[${currentBot}]}) {
-			/echo check_TankAndXTargetNeedHeal xtarget setting interrupt flag
+			/echo [${Time}]: check_TankAndXTargetNeedHeal xtarget setting interrupt flag
 			/varset c_SubToRun FALSE
-			/RETURN
+			/return
 		}
 	}
+/Return
+
+
+|---------------------------------------------------------------------------|
+|- Used with heals spells to interrupt so that we can heal tanks/xtargets  -|
+|---------------------------------------------------------------------------|
+SUB check_TankNeedHeal
+
+	/declare currentBot string local NULL
+	/declare currentSpellIndx int local
+	/declare xtargetIndex int local NULL
+	/declare numXTargets int local 13
+	/declare t int local
+	/declare s int local	
+
+	/varset c_SubToRun TRUE
+
+
+	/if (${Spawn[id ${Target.ID}].PctHPs} > ${interruptHealPct}) {
+		/echo [${Time}]: check_TankNeedHeal target above threshold for heals, setting interrupt flag
+		/varset c_SubToRun FALSE
+		/return
+	}
+	/if (${healTanks}) {
+		|/echo check_HealTankCasting_DuringDetrimental checking tank heals
+		/for t 1 to ${tanks.Size}
+			/for s 1 to ${tankHeals2D.Size[1]}
+				|/echo Tank HP ${NetBots[${tanks[${t}]}].PctHPs} vs configured ${tankHeals2D[${s},${iHealPct}]}
+				/if (${Bool[${NetBots[${tanks[${t}]}].InZone}]} && ${NetBots[${tanks[${t}]}].PctHPs} <= ${tankHeals2D[${s},${iHealPct}]}) {
+					|interrupt any determenal spell if casting if we are supposed to be healing		
+					/if (${check_Distance[${NetBots[${tanks[${t}]}].ID},${tankHeals2D[${s},${iMyRange}]}]}) {
+						
+						/varset currentBot ${tanks[${t}]}
+						/varset currentSpellIndx ${s}
+					}
+				}
+			/if (!${Bool[${currentBot}]}) /next s
+		/if (!${Bool[${currentBot}]}) /next t
+
+		/if (${Bool[${currentBot}]}) {
+			/echo [${Time}]: check_TankNeedHeal tank needs heal setting interrupt flag
+			/varset c_SubToRun FALSE
+			/RETURN
+		}	
+		|/echo check_HealCasting_DuringDetrimental no target found
+	}
+	
 /Return
 |----------------------------------------|
 |- Checks while casting important heals	-|
 |----------------------------------------|
 SUB check_HealImportantCasting
-	/varset c_SubToRun FALSE
-	/if (${castEndTime} > ${interruptImportantCastSec} || ${Spawn[id ${Target.ID}].PctHPs} < ${interruptHealPct}) /varset c_SubToRun TRUE
+	/varset c_SubToRun TRUE
+	/if (${Spawn[id ${Target.ID}].PctHPs} > ${interruptHealPct}) {
+		/echo [${Time}]: check_HealImportantCasting target above threshold for heals, setting interrupt flag
+		/varset c_SubToRun FALSE
+	}
+	
 /RETURN
 |----------------------------------------|
 |- Checks while casting all heals		-|
 |----------------------------------------|
 SUB check_HealAllCasting
-	/varset c_SubToRun FALSE
-	/if (${castEndTime} > ${interruptAllCastSec} || ${Spawn[id ${Target.ID}].PctHPs} < ${interruptHealPct}) /varset c_SubToRun TRUE
+	/varset c_SubToRun TRUE
+	/if (${Spawn[id ${Target.ID}].PctHPs} > ${interruptHealPct}) {
+		/echo [${Time}]: check_HealAllCasting target above threshold for heals, setting interrupt flag
+		/varset c_SubToRun FALSE
+	}
 /RETURN
 |----------------------------------------|
 |- Checks while casting xtarget heals	-|
 |----------------------------------------|
 SUB check_HealXTargetCasting
-	/varset c_SubToRun FALSE
-	/if (${castEndTime} > ${interruptXTargetCastSec} || ${Spawn[id ${Target.ID}].PctHPs} < ${interruptHealPct}) /varset c_SubToRun TRUE
+	/varset c_SubToRun TRUE
+	/if (${Spawn[id ${Target.ID}].PctHPs} > ${interruptHealPct}) {
+		/echo [${Time}]: check_HealXTargetCasting target above threshold for heals, setting interrupt flag
+		/varset c_SubToRun FALSE
+	}
 /RETURN
 |----------------------------------------|
 |- Checks while casting pet heals		-|
 |----------------------------------------|
 SUB check_HealPetCasting
-	/varset c_SubToRun FALSE
-	/if (${castEndTime} > ${interruptAllCastSec} || ${Spawn[id ${Target.ID}].PctHPs} < ${interruptHealPct}) /varset c_SubToRun TRUE
+	/varset c_SubToRun TRUE
+	/if (${Spawn[id ${Target.ID}].PctHPs} > ${interruptHealPct}) {
+		/echo [${Time}]: check_HealPetCasting target above threshold for heals, setting interrupt flag
+		/varset c_SubToRun FALSE
+	}
 /RETURN
 
 |-------------------------------------------|

--- a/Macros/e3 Includes/e3_Loot.inc
+++ b/Macros/e3 Includes/e3_Loot.inc
@@ -544,10 +544,10 @@ SUB loot_Setup
   /call iniToVarV "${genSettings_Ini},Loot,Loot in Combat" combatLooting bool outer
 	| Import character settings
 	/if (${Bool[${Ini[${Character_Ini},Misc,Auto-Loot (On/Off)]}]}) /call iniToVarV "${Character_Ini},Misc,Auto-Loot (On/Off)" Auto_Loot bool outer
-  	/if (${Ini[${genSettings_Ini},Loot,Loot Only Stackable: Enable (On/Off)].Length}) /call iniToVarV "${genSettings_Ini},Loot,Loot Only Stackable: Enable (On/Off)" LootOnlyStackableEnabled bool outer
-  	/if (${Ini[${genSettings_Ini},Loot,Loot Only Stackable: With Value Greater Than Or Equal in Copper].Length}) /call iniToVarV "${genSettings_Ini},Loot,Loot Only Stackable: With Value Greater Than Or Equal in Copper" LootOnlyStackableValueGreater int outer
-  	/if (${Ini[${genSettings_Ini},Loot,Loot Only Stackable: Loot common tradeskill items ie:pelts ores silks etc (On/Off)].Length}) /call iniToVarV "${genSettings_Ini},Loot,Loot Only Stackable: Loot common tradeskill items ie:pelts ores silks etc (On/Off)" LootOnlyStackableTradeSkillsCommon bool outer
-  	/if (${Ini[${genSettings_Ini},Loot,Loot Only Stackable: Loot all Tradeskill items (On/Off)].Length})  /call iniToVarV "${genSettings_Ini},Loot,Loot Only Stackable: Loot all Tradeskill items (On/Off)" LootOnlyStackableTradeSkillsALL bool outer
+  /if (${Ini[${genSettings_Ini},Loot,Loot Only Stackable: Enable (On/Off)].Length}) /call iniToVarV "${genSettings_Ini},Loot,Loot Only Stackable: Enable (On/Off)" LootOnlyStackableEnabled bool outer
+  /if (${Ini[${genSettings_Ini},Loot,Loot Only Stackable: With Value Greater Than Or Equal in Copper].Length}) /call iniToVarV "${genSettings_Ini},Loot,Loot Only Stackable: With Value Greater Than Or Equal in Copper" LootOnlyStackableValueGreater int outer
+  /if (${Ini[${genSettings_Ini},Loot,Loot Only Stackable: Loot common tradeskill items ie:pelts ores silks etc (On/Off)].Length}) /call iniToVarV "${genSettings_Ini},Loot,Loot Only Stackable: Loot common tradeskill items ie:pelts ores silks etc (On/Off)" LootOnlyStackableTradeSkillsCommon bool outer
+  /if (${Ini[${genSettings_Ini},Loot,Loot Only Stackable: Loot all Tradeskill items (On/Off)].Length})  /call iniToVarV "${genSettings_Ini},Loot,Loot Only Stackable: Loot all Tradeskill items (On/Off)" LootOnlyStackableTradeSkillsALL bool outer
 
 /if (${Debug} || ${Debug_Loot}) /echo <== _Setup -|
 /RETURN

--- a/Macros/e3 Includes/e3_Loot.inc
+++ b/Macros/e3 Includes/e3_Loot.inc
@@ -194,7 +194,7 @@ SUB lootCorpse
       |Stackable check code      
       /if (${Corpse.Item[${i}].Stackable}) {
 
-        /echo Loot Only Stackable: value of item=${Corpse.Item[${i}].Value} vs setting=${LootOnlyStackableValueGreater}
+        /echo [${Time}]: Loot Only Stackable: value of item=${Corpse.Item[${i}].Value} vs setting=${LootOnlyStackableValueGreater}
         
         /varset lootSetting Skip
         /varset importantItem FALSE
@@ -220,7 +220,7 @@ SUB lootCorpse
         }
         /if (${importantItem}) {
 
-          /echo Loot Only Stackable:hard coded important item ${Corpse.Item[${i}].Name}
+          /echo [${Time}]: Loot Only Stackable:hard coded important item ${Corpse.Item[${i}].Name}
         }
         |end items that are tackable but have no vendor value.
 
@@ -230,7 +230,7 @@ SUB lootCorpse
 
             /if (${Corpse.Item[${i}].Value} >=${LootOnlyStackableValueGreater} ) {
               /varset importantItem True
-              /echo Loot Only Stackable:Keeping item ${Corpse.Item[${i}].Name} as its value is above or equal to threshhold
+              /echo [${Time}]: Loot Only Stackable:Keeping item ${Corpse.Item[${i}].Name} as its value is above or equal to threshhold
             } 
         }
         
@@ -238,7 +238,7 @@ SUB lootCorpse
 
           |We loot all trade skills 
             /varset importantItem TRUE
-            /echo Loot Only Stackable:Keeping item ${Corpse.Item[${i}].Name} as its a tradeskill item and we are set to loot all tradeskills.
+            /echo [${Time}]: Loot Only Stackable:Keeping item ${Corpse.Item[${i}].Name} as its a tradeskill item and we are set to loot all tradeskills.
         } 
         |/echo common trades skill var setting = ${LootOnlyStackableTradeSkillsCommon}
         /if (!${importantItem} && ${LootOnlyStackableTradeSkillsCommon}) {
@@ -254,7 +254,7 @@ SUB lootCorpse
           }
 
           /if (${importantItem}) {
-            /echo Loot Only Stackable:Keeping item ${Corpse.Item[${i}].Name} as its a common tradeskill item.
+            /echo [${Time}]: Loot Only Stackable:Keeping item ${Corpse.Item[${i}].Name} as its a common tradeskill item.
           }
           
         }
@@ -328,34 +328,46 @@ SUB lootCorpse
           /goto :skipItem
         }
       } else /if (${Me.LargestFreeInventory} < ${Corpse.Item[${i}].Size}) {
-        /echo [Loot]: I don't have a free inventory space large enough to hold [${itemName}].
+        /echo [${Time}]: Loot: I don't have a free inventory space large enough to hold [${itemName}].
         /goto :skipItem
       }  else /if (!${Me.FreeInventory}) {
         /if (${Debug} || ${Debug_Loot}) /bc [+g+] [Auto-Loot]: No Free Space
         /goto :skipItem
       }
       |/if (${Debug} || ${Debug_Loot}) /bc [+g+] [Auto-Loot]: Looting [${itemName}] keep
-      /call loot_Handle ${i} keep
+      
+      |if we are keeping the item simply right click it for **far** faster looting.
+      |delay 4 is needed per item so we don't accidently skip. Unsure how much delay will be impacted. 
+      |if it is, uncomment out loot_handle and commonent out the itemnotify and /delay 4
+      /itemnotify loot${i} rightmouseup
+      /delay 4
+      |/call loot_Handle ${i} keep
       |/if (${Debug} || ${Debug_Loot}) /echo Done Looting i: ${i}
-      /delay 1
+     
     }
   :skipItem
 
   |/if (${Debug} || ${Debug_Loot}) /echo Done with slot i: ${i}
   /next i
-  /delay 1
+  |/delay 1
   |looting done, if items leftover link them
-  /if (${Corpse.Items}) {
-    /keypress /
-    /delay 1
-    /call Type "${linkChannel} ${Target.ID}-"
-    /delay 1
-    /notify LootWnd BroadcastButton leftmouseup
-    /delay 1
-    /keypress enter chat
+  |if numitems was 0, no reason to query the corpse again.
+  /if (${numItems}>0) {
+    /if (${Corpse.Items}) {
+      /keypress /
+      /delay 1
+      /call Type "${linkChannel} ${Target.ID}-"
+      /delay 1
+      /notify LootWnd BroadcastButton leftmouseup
+      /delay 1
+      /keypress enter chat
+    }
   }
   :skipLoot
-  /if (${Corpse.Open}) /notify LootWnd DoneButton leftmouseup
+  /if (${Corpse.Open}) {
+    /keypress esc
+    |/notify LootWnd DoneButton leftmouseup
+  } 
   /delay 1s !${Window[LootWnd].Open}
   |/if (${Debug} || ${Debug_Loot}) /echo Done Looting ${Time}
 /return
@@ -433,7 +445,8 @@ SUB loot_Handle(int slotNum, handle)
 	/declare lootTimer timer local 3s
 	:retry_Loot
 	| Try to loot the specified item from the corpse.
-	/itemnotify loot${slotNum} leftmouseup
+	/itemnotify loot${slotNum} rightmouseup
+
 	/delay 1s ${Cursor.ID} || ${Window[ConfirmationDialogBox].Open} || ${Window[QuantityWnd].Open}
 	| If the item has been looted, decide what to do with it.
 	/if (${Cursor.ID}) {

--- a/Macros/e3 Includes/e3_NowCast.inc
+++ b/Macros/e3 Includes/e3_NowCast.inc
@@ -106,13 +106,14 @@ SUB castNowSpells
     /declare spellArgs string local 
     /declare spellName string local
     /declare spellTargetID int local
-    
+    /declare GCDOver bool local false
+
     /while (${nowSpellArrayQueueCount}>0) {
         |get the value out of the queue
         /call NowCast_CircularQueue_Pop
         /varset spellArgs ${Macro.Return}
         
-         /echo NowCast: pulling from queue:${spellArgs}
+         |/echo NowCast: pulling from queue:${spellArgs}
 
         /varset spellName ${spellArgs.Arg[1,,]}
         /varset spellTargetID ${spellArgs.Arg[2,,]}
@@ -125,10 +126,29 @@ SUB castNowSpells
         /if (${DebugNowCast}) /echo nowCast targetID: ${spellTargetID} 	
         | Check if SpellReady/AltAbilityReady
 
-        /if (${Bool[${Me.Book[${spellName}]}]}) {
-            |if this is a spell, delay up to 0.3 sec for the spell gems to be ready
-            /delay 1s ${Me.SpellReady[${spellName}]}
-        }
+        /if (${Bool[${Me.Book[${spellName}]}]} && !${Me.Class.ShortName.Equal[BRD]}) {
+           
+            /varset GCDOver false
+            /while (!${GCDOver}) {
+                |/echo [${Time}] Now_cast: checking to see if GCD is over
+                /call check_GCD 
+                /varset GCDOver ${Macro.Return}
+                /delay 1
+            }
+        } else /if (${Me.Class.ShortName.Equal[BRD]}) {
+               
+                /while (${Window[CastingWindow].Open}) {
+                    /delay 1
+                }
+                /delay 1
+                /stopcast
+                /varset GCDOver false
+                /while (!${GCDOver}) {
+                    /call check_GCD 
+                    /varset GCDOver ${Macro.Return}
+                    /delay 1
+                }
+        }   
         /if (${Me.SpellReady[${spellName}]} || ${Me.AltAbilityReady[${spellName}]} || ${Me.ItemReady[${spellName}]}) {
             /call castNowSpell "${spellName}" ${spellTargetID}
             /if (!(${ActionTaken} && ${castReturn.Equal[CAST_SUCCESS]})) {
@@ -158,6 +178,7 @@ SUB castNowSpell(spellName, targetID)
         /varset g_CastNowSpellCasting TRUE
         /call castSimpleSpell "${whatToCast}" ${targetID}
         /varset g_CastNowSpellCasting False
+       
 	}
 /RETURN
 | Add a spell to the queue with no targetid
@@ -181,7 +202,7 @@ SUB event_nowCast(line, ChatSender, Caster, spellName)
         /echo CastNow Queue is maxed, dropping ${spellName},${nowTargetID}
         /return
     }
-    /echo NowCast: Inserting into queue:  "${spellName},${nowTargetID}"
+    |/echo NowCast: Inserting into queue:  "${spellName},${nowTargetID}"
     /call NowCast_CircularQueue_Insert "${spellName},${nowTargetID}"
 	|c_SubToRun is used internally by e3_Cast, we are flaggint that if something was casting, we would like to interrupt 
     |once we leave this  e3_Casting should check the flag and then call an interrupt

--- a/Macros/e3 Includes/e3_NowCast.inc
+++ b/Macros/e3 Includes/e3_NowCast.inc
@@ -78,7 +78,7 @@ SUB castNowSpells
         /if (${Me.SpellReady[${spellName}]} || ${Me.AltAbilityReady[${spellName}]} || ${Me.ItemReady[${spellName}]}) {
             /call castNowSpell "${spellName}" ${spellTargetID}
             /if (!(${ActionTaken} && ${castReturn.Equal[CAST_SUCCESS]})) {
-                /echo <NowCast>: Failed to cast ${spellName} due to ${castReturn}
+                /bc <NowCast>: Failed to cast ${spellName} due to ${castReturn}
             } else /if (${nowSpellArrayQueueCount}>0 ) {
                 |give times global cooldown if this is not an item
                 /if (!${Bool[${FindItemCount[=${spellName}]}]}) {

--- a/Macros/e3 Includes/e3_NowCast.inc
+++ b/Macros/e3 Includes/e3_NowCast.inc
@@ -46,6 +46,59 @@ Sub NowCast_CircularQueue_Pop
     /varcalc nowSpellArrayQueueCount ${nowSpellArrayQueueCount}-1
 
 /return ${returnValue}
+
+
+Sub NowCast_CircularQueue_Empty
+    /varset nowSpellArrayQueueCount 0
+    /varset nowSpellArrayQueueIndexFront 0
+    /varset nowSpellArrayQueueIndexBack -1
+
+/return
+
+Sub NowCast_CircularQueue_Peek
+    /if (${nowSpellArrayQueueCount}==0) {
+        /echo NowCast Queue Empty Already
+        /return
+    }
+    /declare returnValue string local ${nowSpellArrayQueue[${Math.Calc[${nowSpellArrayQueueIndexFront}+1]}]}
+    
+/return ${returnValue}
+
+|0 based index
+Sub NowCast_CircularQueue_PeekIndex(indexValue)
+    /if (${nowSpellArrayQueueCount}==0) {
+        /echo NowCast Queue Empty Already
+        /return
+    }
+   
+    /declare arrayIndex int local  ${Math.Calc[(${nowSpellArrayQueueIndexFront} + ${indexValue} ) % ${nowSpellArrayQueueMax}]}
+    /varCalc arrayIndex ${arrayIndex}+1
+    /declare returnValue string local ${nowSpellArrayQueue[${arrayIndex}]}
+    |/echo PeekIndex Front:${nowSpellArrayQueueIndexFront} back:${nowSpellArrayQueueIndexBack}  of input index: ${indexValue}, array index:${arrayIndex} return value: ${returnValue}
+
+/return ${returnValue}
+
+Sub NowCast_CircularQueue_PrintQueue
+  /if (${nowSpellArrayQueueCount}==0) {
+    /echo NowCast Queue Empty Already
+    /return
+  }
+  /declare counter int local 0
+  /declare itemValue string local
+
+  |loop through the current queue,
+  /while (${counter}< ${nowSpellArrayQueueCount}) {
+    /call NowCast_CircularQueue_PeekIndex ${counter}
+    /varset itemValue ${Macro.Return}
+    /echo ${counter}) ${itemValue}
+    /varcalc counter ${counter}+1
+  }
+    
+/return
+
+
+
+
 | Casts the spell at the front of the queue
 SUB castNowSpells
     |a check to make double sure we notify the rest of the program we are not casting yet.
@@ -72,9 +125,8 @@ SUB castNowSpells
 
         /if (${Bool[${Me.Book[${spellName}]}]}) {
             |if this is a spell, delay up to 0.3 sec for the spell gems to be ready
-            /delay 3 ${Me.SpellReady[${spellName}]}
+            /delay 1s ${Me.SpellReady[${spellName}]}
         }
-       
         /if (${Me.SpellReady[${spellName}]} || ${Me.AltAbilityReady[${spellName}]} || ${Me.ItemReady[${spellName}]}) {
             /call castNowSpell "${spellName}" ${spellTargetID}
             /if (!(${ActionTaken} && ${castReturn.Equal[CAST_SUCCESS]})) {

--- a/Macros/e3 Includes/e3_NowCast.inc
+++ b/Macros/e3 Includes/e3_NowCast.inc
@@ -112,6 +112,8 @@ SUB castNowSpells
         /call NowCast_CircularQueue_Pop
         /varset spellArgs ${Macro.Return}
         
+         /echo NowCast: pulling from queue:${spellArgs}
+
         /varset spellName ${spellArgs.Arg[1,,]}
         /varset spellTargetID ${spellArgs.Arg[2,,]}
 
@@ -179,6 +181,7 @@ SUB event_nowCast(line, ChatSender, Caster, spellName)
         /echo CastNow Queue is maxed, dropping ${spellName},${nowTargetID}
         /return
     }
+    /echo NowCast: Inserting into queue:  "${spellName},${nowTargetID}"
     /call NowCast_CircularQueue_Insert "${spellName},${nowTargetID}"
 	|c_SubToRun is used internally by e3_Cast, we are flaggint that if something was casting, we would like to interrupt 
     |once we leave this  e3_Casting should check the flag and then call an interrupt

--- a/Macros/e3 Includes/e3_NowCast.inc
+++ b/Macros/e3 Includes/e3_NowCast.inc
@@ -69,6 +69,12 @@ SUB castNowSpells
         }
         /if (${DebugNowCast}) /echo nowCast targetID: ${spellTargetID} 	
         | Check if SpellReady/AltAbilityReady
+
+        /if (${Bool[${Me.Book[${spellName}]}]}) {
+            |if this is a spell, delay up to 0.3 sec for the spell gems to be ready
+            /delay 3 ${Me.SpellReady[${spellName}]}
+        }
+       
         /if (${Me.SpellReady[${spellName}]} || ${Me.AltAbilityReady[${spellName}]} || ${Me.ItemReady[${spellName}]}) {
             /call castNowSpell "${spellName}" ${spellTargetID}
             /if (!(${ActionTaken} && ${castReturn.Equal[CAST_SUCCESS]})) {

--- a/Macros/e3 Includes/e3_NowCast.inc
+++ b/Macros/e3 Includes/e3_NowCast.inc
@@ -112,22 +112,22 @@ SUB castNowSpell(spellName, targetID)
 SUB event_nowCast(line, ChatSender, Caster, spellName)
     /if (${Bool[${Caster}]} &&!${Me.Name.Equal[${Caster}]}) /return
 
-    /declare targetID int local ${Me.ID}
+    /declare nowTargetID int local ${Me.ID}
     /declare spellIndexStart int local 0
-    /declare targetIDIndex int local 0
+    /declare nowTargetIDIndex int local 0
 
     /if (${Bool[${spellName.Length}]}) {
-        /varset targetIDIndex ${spellName.Find[targetid]}
-        /if (${targetIDIndex}>0) {
-            /varset targetID ${spellName.Token[2,=]}
-            /varset spellName ${spellName.Left[${Math.Calc[${targetIDIndex}-2]}]}       
+        /varset nowTargetIDIndex ${spellName.Find[targetid]}
+        /if (${nowTargetIDIndex}>0) {
+            /varset nowTargetID ${spellName.Token[2,=]}
+            /varset spellName ${spellName.Left[${Math.Calc[${nowTargetIDIndex}-2]}]}       
         }
     }
     /if (${nowSpellArrayQueueCount}==${nowSpellArrayQueueMax}) {
-        /echo CastNow Queue is maxed, dropping ${spellName},${targetID}
+        /echo CastNow Queue is maxed, dropping ${spellName},${nowTargetID}
         /return
     }
-    /call NowCast_CircularQueue_Insert "${spellName},${targetID}"
+    /call NowCast_CircularQueue_Insert "${spellName},${nowTargetID}"
 	|c_SubToRun is used internally by e3_Cast, we are flaggint that if something was casting, we would like to interrupt 
     |once we leave this  e3_Casting should check the flag and then call an interrupt
     /if (!${g_CastNowSpellCasting}) /varset c_SubToRun FALSE

--- a/Macros/e3 Includes/e3_NowCast.inc
+++ b/Macros/e3 Includes/e3_NowCast.inc
@@ -150,6 +150,7 @@ SUB castNowSpells
                 }
         }   
         /if (${Me.SpellReady[${spellName}]} || ${Me.AltAbilityReady[${spellName}]} || ${Me.ItemReady[${spellName}]}) {
+            /varset castReturn  
             /call castNowSpell "${spellName}" ${spellTargetID}
             /if (!(${ActionTaken} && ${castReturn.Equal[CAST_SUCCESS]})) {
                 /bc <NowCast>: Failed to cast ${spellName} due to ${castReturn}

--- a/Macros/e3 Includes/e3_Pets.inc
+++ b/Macros/e3 Includes/e3_Pets.inc
@@ -82,10 +82,10 @@ SUB check_petHeal
 		/if (${Defined[petMendPct]}) {
       /if (${Me.Pet.PctHPs} < ${petMendPct}) {
         /if (${Me.AltAbilityReady[Replenish Companion]}) {
-          /casting "Replenish Companion" "-targetid|${Me.Pet.ID}"
+          /call castSimpleSpell "Replenish Companion" ${Me.Pet.ID}
           /varset petMended TRUE
         } else /if (${Me.AltAbilityReady[Mend Companion]}) {
-          /casting "Mend Companion" "-targetid|${Me.Pet.ID}"
+          /call castSimpleSpell "Mend Companion" ${Me.Pet.ID}
           /varset petMended TRUE
         }
       }
@@ -151,8 +151,7 @@ SUB event_suspendMinion(live, ChatSender)
     /docommand ${ChatToggle} Suspending my pet...
     /if (${Me.AltAbilityReady[Suspended Minion]}) {
       /if (${Me.Casting.ID}) /call interrupt
-      /casting "Suspended Minion|alt" -maxtries|2
-      /delay 5s !${Me.Pet.ID}
+      /call castSimpleSpell "Suspended Minion" 0
       /varset currently_Suspended TRUE
     }
     /if (${Me.Pet.ID}) /pet get lost
@@ -171,7 +170,7 @@ SUB event_returnMinion(line, ChatSender)
     /if (${suspend_Pets}) {
       /docommand ${ChatToggle} Returning my pet...
       /if (${currently_Suspended}) {
-        /casting "Suspended Minion|alt" -maxtries|2
+        /call castSimpleSpell "Suspended Minion" 0
         /varset currently_Suspended FALSE
       }
       /varset suspend_Pets FALSE

--- a/Macros/e3 Includes/e3_Setup.inc
+++ b/Macros/e3 Includes/e3_Setup.inc
@@ -142,6 +142,7 @@ SUB e3_Setup(modeSelect)
 	/next i
   |Set Turbo per class based on configuration
   /if (${${IniMode}[${advSettings_Ini},Turbo,${Me.Class.ShortName}].Length}) /declare classTurbo int outer ${${IniMode}[${advSettings_Ini},Turbo,${Me.Class.ShortName}]}
+  
   /squelch /turbo ${classTurbo}
 
 	|Ewiclip: Adding auto-casting of Necromancer orb heals. 

--- a/Macros/e3 Includes/e3_Setup.inc
+++ b/Macros/e3 Includes/e3_Setup.inc
@@ -54,8 +54,10 @@ SUB e3_Setup(modeSelect)
 	/declare reloadOnLoot bool outer FALSE
 	/declare missingSpellItem string outer
 	/declare numInventorySlots int outer 10
+	/declare previousSpellGemThatWasCast int outer -1
 	/call BuildSpellArrayDefinedValues
 	/call NowCastDefinedValues
+	/call BardClassDefinedValues
 
 	/if (${modeSelect.Equal[Debug]}) /varset Debug TRUE
 	| The file path for e3 Data.ini will still need to be updated in corresponding includes because you must use /noparse to write variables to inis.

--- a/Macros/e3 Includes/e3_Tanking.inc
+++ b/Macros/e3 Includes/e3_Tanking.inc
@@ -74,11 +74,11 @@ SUB peelTank
     } else {
       /if (${Me.CombatAbilityReady[Mock]}) {
         /doability Mock
-        /delay 2
+        /delay 3
       }
-      /if (${Me.CombatAbilityReady[Bazu Bellow]}) /doability "Bazu Bellow"
-      /if (${Me.AltAbilityReady[Divine Stun]}) /casting "Divine Stun"
-      /if (${Me.SpellReady[Terror of Discord]}) /casting "Terror of Discord"
+      /if (${Me.CombatAbilityReady[Bazu Bellow]}) /call castSimpleSpell "Bazu Bellow" 0
+      /if (${Me.AltAbilityReady[Divine Stun]}) /call castSimpleSpell "Divine Stun" 0
+      /if (${Me.SpellReady[Terror of Discord]}) /call castSimpleSpell "Terror of Discord" 0
     }
   }
 
@@ -113,11 +113,11 @@ SUB peelTank
           /doability Taunt
           /if (${Me.CombatAbilityReady[Mock]}) {
             /doability Mock
-            /delay 2
+            /delay 3
           }
-          /if (${Me.CombatAbilityReady[Bazu Bellow]}) /doability "Bazu Bellow"
-          /if (${Me.AltAbilityReady[Divine Stun]}) /casting "Divine Stun"
-          /if (${Me.SpellReady[Terror of Discord]}) /casting "Terror of Discord"
+          /if (${Me.CombatAbilityReady[Bazu Bellow]}) /call castSimpleSpell "Bazu Bellow" 0
+          /if (${Me.AltAbilityReady[Divine Stun]}) /call castSimpleSpell "Divine Stun" 0
+          /if (${Me.SpellReady[Terror of Discord]}) /call castSimpleSpell "Terror of Discord" 0
           /return
         } else {
           /varset peelTarget 0

--- a/Macros/e3 Includes/e3_Utilities.inc
+++ b/Macros/e3 Includes/e3_Utilities.inc
@@ -1372,7 +1372,7 @@ SUB checkEventArgs(ChatSender, eventLine, UZR, ArgData)
     /call argueString include| "${eventLine}"
     /if (${check_selectedBots[${c_argueString},${ChatSender}]}) /varset includeBot TRUE
   }
-  |/echo ${userValidated} && ${includeBot} && ${inRange} && ${inZone}
+  |/echo checkEventArgs:${userValidated} && ${includeBot} && ${inRange} && ${inZone}
   /if (${userValidated} && ${includeBot} && ${inRange} && ${inZone}) /varset c_eventArg TRUE
   /varset c_eventArgChatSender ${ChatSender}
   /if (${Bool[${ArgData}]}) {

--- a/Macros/e3 Includes/e3_Utilities.inc
+++ b/Macros/e3 Includes/e3_Utilities.inc
@@ -839,9 +839,11 @@ SUB createTimer(timerName, timerSetting)
 /if (${Debug}) /echo |- createTimer ==>
   /if (${timerName.Length} == 0) /return
   /if (${Defined[${timerName}]}) {
+	|/echo Setting value of Timer: ${timerName} : ${timerSetting}
     /varset ${timerName} ${timerSetting}
   } else {
     /declare ${timerName} timer outer ${timerSetting}
+	|/echo Creating value of Timer: ${timerName} : ${timerSetting}
     /call BuildArray timerArray ${timerName}
   }
 /if (${Debug}) /echo <== createTimer -| created ${timerName} [${${timerName}}]

--- a/Macros/e3 Includes/e3_Utilities.inc
+++ b/Macros/e3 Includes/e3_Utilities.inc
@@ -191,7 +191,7 @@ SUB ListToArray(ArrayName, Data, delimiter)
 Sub BuildSpellArrayDefinedValues()
 
 	/if (!${Defined[SpellProp]}) {
-		/declare SpellProp[45] string outer 0
+		/declare SpellProp[46] string outer 0
 		/varset SpellProp[1] CastName
 		/varset SpellProp[2] CastType
 		/varset SpellProp[3] TargetType
@@ -237,6 +237,7 @@ Sub BuildSpellArrayDefinedValues()
     	/varset SpellProp[42] Ifs
 		/varset SpellProp[43] BeforeSpell
 		/varset SpellProp[44] AfterSpell
+		/varset SpellProp[45] NoInterrupt
 
 		
 	}
@@ -284,6 +285,7 @@ Sub BuildSpellArrayDefinedValues()
   	/if (!${Defined[iIfs]})		/declare iIfs int outer 42
 	/if (!${Defined[iBeforeSpell]})		/declare iBeforeSpell int outer 43
 	/if (!${Defined[iAfterSpell]})		/declare iAfterSpell int outer 44
+	/if (!${Defined[iNoInterrupt]})		/declare iNoInterrupt int outer 45
 
 /return
 
@@ -634,6 +636,11 @@ SUB BuildSpellArrayBase(ArrayName, NewArrayName, SkipParams)
 				/call argueString Gem| "${${ArrayName}[${i}]}"
 				/varset ${NewArrayName}[${i},${iSpellGem}] ${c_argueString}
 			}
+			|iNoInterrupt
+			/if (${${ArrayName}[${i}].Find[/NoInterrupt]}) {
+				/varset ${NewArrayName}[${i},${iNoInterrupt}] 1
+			}
+
 			| get AfterSpell
 			/if (${${ArrayName}[${i}].Find[/AfterSpell|]}) {
 				/varset printMin true

--- a/Macros/e3 Includes/e3_Utilities.inc
+++ b/Macros/e3 Includes/e3_Utilities.inc
@@ -1103,8 +1103,8 @@ SUB check_macroTimers
 	/declare SpentTimerList string local
 	/for i 1 to ${timerArray.Size}
     /if (${Defined[${timerArray[${i}]}]}) {
-		  /if (!${${timerArray[${i}]}}) {
-        /if (${Debug}) /echo Deleting timer: ${timerArray[${i}]}
+		/if (!${${timerArray[${i}]}}) {
+        		/echo Deleting timer: ${timerArray[${i}]}
 			    /varcalc SpentTimerCounter ${SpentTimerCounter} + 1
 				/deletevar ${timerArray[${i}]}
 				/varset SpentTimerList ${SpentTimerList}${i},
@@ -1115,8 +1115,8 @@ SUB check_macroTimers
 	/if (${SpentTimerCounter}==${timerArray.Size}) {
 		/if (${Debug}) /echo All timers have been cleared.
 		/deletevar timerArray
-	} else {
-    /call RemoveArrayElements "timerArray" ${SpentTimerList}"
+	} else /if (${SpentTimerCounter}>0) {
+		/call RemoveArrayElements "timerArray" ${SpentTimerList}"
 	}
 /if (${Debug}) /echo <== check_macroTimers -|
 /RETURN

--- a/Macros/e3 Includes/e3_Utilities.inc
+++ b/Macros/e3 Includes/e3_Utilities.inc
@@ -308,16 +308,25 @@ SUB BuildSingleSpellArrayBase(spellName, NewArrayName, SkipParams)
 	}
 	
 	| get SpellName
+	/declare inputValue string local ${spellName}
+	/varset spellName  ${spellName.Arg[1,/]}
 
 	/declare oldName string local 
 	/varset oldName ${${NewArrayName}[1,${iCastName}]}
 	
 	/if (${oldName.Equal[${spellName}]}) {
-		|don't have to do anything just return
+		
+		| get SpellGem
+		/if (${inputValue.Find[/Gem|]}) {
+			/call argueString Gem| "${inputValue}"
+			/varset ${NewArrayName}[1,${iSpellGem}] ${c_argueString}
+		} else {
+			/varset ${NewArrayName}[1,${iSpellGem}] 0
+		}
+		|don't have to do anything else just return	
 		/return
 	}
 	/varset ${NewArrayName}[1,${iCastName}] ${spellName}
-	
 	/if (${Bool[${Me.AltAbility[${spellName}].Spell}]}) {
 		/varset ${NewArrayName}[1,${iCastType}] AA
 	} else /if (${Me.Book[${spellName}]}) {
@@ -326,12 +335,11 @@ SUB BuildSingleSpellArrayBase(spellName, NewArrayName, SkipParams)
 		/varset ${NewArrayName}[1,${iCastType}] Disc
 	} else /if (${Me.Ability[${spellName}]}) {
 		/varset ${NewArrayName}[1,${iCastType}] Ability			
-	} else /if (${Me.ItemReady[${spellName}]}) {
-		/varset ${NewArrayName}[1,${iCastType}] Item
 	} else {
-		/varset ${NewArrayName}[1,${iCastType}] NotFound
-	}
-	
+		|default to item , as we simply don't know if its an item that may have to be
+		|resummoned like a mage orb and may not be in the bags atm
+		/varset ${NewArrayName}[1,${iCastType}] Item
+	} 
 	|set the normal defaults
 	/varset ${NewArrayName}[1,${iSpellGem}] ${DefaultGem}
 	/varset ${NewArrayName}[1,${iMaxTries}] 5
@@ -342,7 +350,11 @@ SUB BuildSingleSpellArrayBase(spellName, NewArrayName, SkipParams)
 	/varset ${NewArrayName}[1,${iIfs}] TRUE
 	/varset ${NewArrayName}[1,${iBeforeSpell}]  
 	/varset ${NewArrayName}[1,${iAfterSpell}]  
-	
+	|deal with the gems
+	/if (${inputValue.Find[/Gem|]}) {
+		/call argueString Gem| "${inputValue}"
+		/varset ${NewArrayName}[1,${iSpellGem}] ${c_argueString}
+	}
 	|Fill out information based off Item/AA/Spell/Disc
 	/if (${${NewArrayName}[1,${iCastType}].Equal[Item]}) {
 		|ITEM INFORMATION
@@ -458,7 +470,9 @@ SUB BuildSingleSpellArrayBase(spellName, NewArrayName, SkipParams)
 
 
 	|Print out debug information if requsted
-	/if (${printAll} || ${printMin} || ${isHealArray}) {
+	/declare printAll bool local False
+	/declare printMin bool local False
+	/if (${printAll} || ${printMin}) {
 
 		/if (${printAll} || ${printMin}) /echo CastName ${${NewArrayName}[1,${iCastName}]}
 		/if (${printAll}  || ${printMin}) /echo CastType ${${NewArrayName}[1,${iCastType}]}

--- a/Macros/e3 Includes/e3_Utilities.inc
+++ b/Macros/e3 Includes/e3_Utilities.inc
@@ -326,7 +326,7 @@ SUB BuildSingleSpellArrayBase(spellName, NewArrayName, SkipParams)
 		/varset ${NewArrayName}[1,${iCastType}] Disc
 	} else /if (${Me.Ability[${spellName}]}) {
 		/varset ${NewArrayName}[1,${iCastType}] Ability			
-	} else /if (${Me.ItemReady[]}) {
+	} else /if (${Me.ItemReady[${spellName}]}) {
 		/varset ${NewArrayName}[1,${iCastType}] Item
 	} else {
 		/varset ${NewArrayName}[1,${iCastType}] NotFound
@@ -348,6 +348,8 @@ SUB BuildSingleSpellArrayBase(spellName, NewArrayName, SkipParams)
 		|ITEM INFORMATION
 		|Instead of calling FindItem 12 times, we call it twice and get a direct reference to the item in question
 	| ${Me.Inventory[23].Item[7].Spell.TargetType}
+		/declare invSlot int local 0
+		/declare bagSlot int local 0
 		/varset invSlot ${FindItem[=${${NewArrayName}[1,${iCastName}]}].ItemSlot}
 		/varset bagSlot ${FindItem[=${${NewArrayName}[1,${iCastName}]}].ItemSlot2}
 

--- a/Macros/e3 Includes/e3_Utilities.inc
+++ b/Macros/e3 Includes/e3_Utilities.inc
@@ -191,7 +191,7 @@ SUB ListToArray(ArrayName, Data, delimiter)
 Sub BuildSpellArrayDefinedValues()
 
 	/if (!${Defined[SpellProp]}) {
-		/declare SpellProp[43] string outer 0
+		/declare SpellProp[45] string outer 0
 		/varset SpellProp[1] CastName
 		/varset SpellProp[2] CastType
 		/varset SpellProp[3] TargetType
@@ -235,6 +235,10 @@ Sub BuildSpellArrayDefinedValues()
 		/varset SpellProp[41] TriggerSpell
 		|----------------------------
     	/varset SpellProp[42] Ifs
+		/varset SpellProp[43] BeforeSpell
+		/varset SpellProp[44] AfterSpell
+
+		
 	}
 	/if (!${Defined[iCastName]})		/declare iCastName int outer 1
 	/if (!${Defined[iCastType]})		/declare iCastType int outer 2
@@ -278,6 +282,8 @@ Sub BuildSpellArrayDefinedValues()
 	/if (!${Defined[iNoStack]})		/declare iNoStack int outer 40
 	/if (!${Defined[iTriggerSpell]})		/declare iTriggerSpell int outer 41
   	/if (!${Defined[iIfs]})		/declare iIfs int outer 42
+	/if (!${Defined[iBeforeSpell]})		/declare iBeforeSpell int outer 43
+	/if (!${Defined[iAfterSpell]})		/declare iAfterSpell int outer 44
 
 /return
 
@@ -291,7 +297,226 @@ Sub BuildSpellArray(ArrayNameFromBuildSpellArray, NewArrayNameFromBuildSpellArra
 	/call BuildSpellArrayBase "${ArrayNameFromBuildSpellArray}" "${NewArrayNameFromBuildSpellArray}" FALSE
 
 /return
+SUB BuildSingleSpellArrayBase(spellName, NewArrayName, SkipParams)
 
+	/if (!${Defined[${NewArrayName}]}) {
+	
+		/declare ${NewArrayName}[1,${SpellProp.Size}] string outer 0
+	
+	} else {
+		|possibly zero out values
+	}
+	
+	| get SpellName
+
+	/declare oldName string local 
+	/varset oldName ${${NewArrayName}[1,${iCastName}]}
+	
+	/if (${oldName.Equal[${spellName}]}) {
+		|don't have to do anything just return
+		/return
+	}
+	/varset ${NewArrayName}[1,${iCastName}] ${spellName}
+	
+	/if (${Bool[${Me.AltAbility[${spellName}].Spell}]}) {
+		/varset ${NewArrayName}[1,${iCastType}] AA
+	} else /if (${Me.Book[${spellName}]}) {
+		/varset ${NewArrayName}[1,${iCastType}] Spell
+	} else /if (${Me.CombatAbility[${spellName}]}) {
+		/varset ${NewArrayName}[1,${iCastType}] Disc
+	} else /if (${Me.Ability[${spellName}]}) {
+		/varset ${NewArrayName}[1,${iCastType}] Ability			
+	} else /if (${Me.ItemReady[]}) {
+		/varset ${NewArrayName}[1,${iCastType}] Item
+	} else {
+		/varset ${NewArrayName}[1,${iCastType}] NotFound
+	}
+	
+	|set the normal defaults
+	/varset ${NewArrayName}[1,${iSpellGem}] ${DefaultGem}
+	/varset ${NewArrayName}[1,${iMaxTries}] 5
+	/varset ${NewArrayName}[1,${iCheckFor}] -1
+	/varset ${NewArrayName}[1,${iMaxMana}] 100
+	/varset ${NewArrayName}[1,${iMinHP}] 70
+	/varset	${NewArrayName}[1,${iZone}] All
+	/varset ${NewArrayName}[1,${iIfs}] TRUE
+	/varset ${NewArrayName}[1,${iBeforeSpell}]  
+	/varset ${NewArrayName}[1,${iAfterSpell}]  
+	
+	|Fill out information based off Item/AA/Spell/Disc
+	/if (${${NewArrayName}[1,${iCastType}].Equal[Item]}) {
+		|ITEM INFORMATION
+		|Instead of calling FindItem 12 times, we call it twice and get a direct reference to the item in question
+	| ${Me.Inventory[23].Item[7].Spell.TargetType}
+		/varset invSlot ${FindItem[=${${NewArrayName}[1,${iCastName}]}].ItemSlot}
+		/varset bagSlot ${FindItem[=${${NewArrayName}[1,${iCastName}]}].ItemSlot2}
+
+		/if (${bagSlot}==-1) {
+			|/echo root item: id:${invSlot} :${${ArrayName}[1].Arg[1,/]}
+			|Means this is not in a bag and in the root inventory
+			/varset	${NewArrayName}[1,${iTargetType}] ${Me.Inventory[${invSlot}].Spell.TargetType}
+			/varset	${NewArrayName}[1,${iDuration}] ${Me.Inventory[${invSlot}].Spell.Duration}
+			/varset	${NewArrayName}[1,${iRecastTime}] ${Me.Inventory[${invSlot}].Spell.RecastTime}
+			/varset	${NewArrayName}[1,${iRecoveryTime}] ${Me.Inventory[${invSlot}].Spell.RecoveryTime}
+			/varset	${NewArrayName}[1,${iMyCastTime}] ${Me.Inventory[${invSlot}].CastTime}
+			/if (${Me.Inventory[${invSlot}].Spell.AERange} > 0) {
+				/varset	${NewArrayName}[1,${iMyRange}] ${Me.Inventory[${invSlot}].Spell.AERange}
+			} else {
+				/varset	${NewArrayName}[1,${iMyRange}] ${Me.Inventory[${invSlot}].Spell.MyRange}
+			}
+			/if (${Me.Inventory[${invSlot}].EffectType.Equal[Click Worn]}) {
+				/varset	${NewArrayName}[1,${iItemMustEquip}] ${Me.Inventory[${invSlot}].WornSlot[1].Name}
+			}
+			/varset	${NewArrayName}[1,${iSpellName}] ${Me.Inventory[${invSlot}].Spell}
+			/varset	${NewArrayName}[1,${iSpellID}] ${Me.Inventory[${invSlot}].Spell.ID}
+			/varset	${NewArrayName}[1,${iCastID}] ${Me.Inventory[${invSlot}].ID}
+			/varset	${NewArrayName}[1,${iSpellType}] ${Me.Inventory[${invSlot}].Spell.SpellType}
+
+		} else {
+			|1 index vs 0 index
+			/varcalc bagSlot ${bagSlot}+1
+			|/echo bag item:id id:${invSlot},${bagSlot}:${${ArrayName}[1].Arg[1,/]}
+			/varset	${NewArrayName}[1,${iTargetType}] ${Me.Inventory[${invSlot}].Item[${bagSlot}].Spell.TargetType}
+			/varset	${NewArrayName}[1,${iDuration}] ${Me.Inventory[${invSlot}].Item[${bagSlot}].Spell.Duration}
+			/varset	${NewArrayName}[1,${iRecastTime}] ${Me.Inventory[${invSlot}].Item[${bagSlot}].Spell.RecastTime}
+			/varset	${NewArrayName}[1,${iRecoveryTime}] ${Me.Inventory[${invSlot}].Item[${bagSlot}].Spell.RecoveryTime}
+			/varset	${NewArrayName}[1,${iMyCastTime}] ${Me.Inventory[${invSlot}].Item[${bagSlot}].CastTime}
+			/if (${Me.Inventory[${invSlot}].Item[${bagSlot}].Spell.AERange} > 0) {
+				/varset	${NewArrayName}[1,${iMyRange}] ${Me.Inventory[${invSlot}].Item[${bagSlot}].Spell.AERange}
+			} else {
+				/varset	${NewArrayName}[1,${iMyRange}] ${Me.Inventory[${invSlot}].Item[${bagSlot}].Spell.MyRange}
+			}
+			/if (${Me.Inventory[${invSlot}].Item[${bagSlot}].EffectType.Equal[Click Worn]}) {
+				/varset	${NewArrayName}[1,${iItemMustEquip}] ${Me.Inventory[${invSlot}].Item[${bagSlot}].WornSlot[1].Name}
+			}
+			/varset	${NewArrayName}[1,${iSpellName}] ${Me.Inventory[${invSlot}].Item[${bagSlot}].Spell}
+			/varset	${NewArrayName}[1,${iSpellID}] ${Me.Inventory[${invSlot}].Item[${bagSlot}].Spell.ID}
+			/varset	${NewArrayName}[1,${iCastID}] ${Me.Inventory[${invSlot}].Item[${bagSlot}].ID}
+			/varset	${NewArrayName}[1,${iSpellType}] ${Me.Inventory[${invSlot}].Item[${bagSlot}].Spell.SpellType}
+		}
+
+	} else /if (${${NewArrayName}[1,${iCastType}].Equal[AA]}) {
+		|AA INFORMATION
+		/varset	${NewArrayName}[1,${iTargetType}] ${Me.AltAbility[${${NewArrayName}[1,${iCastName}]}].Spell.TargetType}
+		/varset	${NewArrayName}[1,${iDuration}] ${Me.AltAbility[${${NewArrayName}[1,${iCastName}]}].Spell.Duration}
+		/varset	${NewArrayName}[1,${iRecastTime}] ${Me.AltAbility[${${NewArrayName}[1,${iCastName}]}].ReuseTime}
+		/varset	${NewArrayName}[1,${iRecoveryTime}] ${Me.AltAbility[${${NewArrayName}[1,${iCastName}]}].Spell.RecoveryTime}
+		/varset	${NewArrayName}[1,${iMyCastTime}] ${Me.AltAbility[${${NewArrayName}[1,${iCastName}]}].Spell.MyCastTime}
+		/if (${Me.AltAbility[${${NewArrayName}[1,${iCastName}]}].Spell.AERange} > 0) {
+			/varset	${NewArrayName}[1,${iMyRange}] ${Me.AltAbility[${${NewArrayName}[1,${iCastName}]}].Spell.AERange}
+		} else {
+			/varset	${NewArrayName}[1,${iMyRange}] ${Me.AltAbility[${${NewArrayName}[1,${iCastName}]}].Spell.MyRange}
+		}
+		/varset	${NewArrayName}[1,${iSpellName}] ${Me.AltAbility[${${NewArrayName}[1,${iCastName}]}].Spell}
+		/varset	${NewArrayName}[1,${iSpellID}] ${Me.AltAbility[${${NewArrayName}[1,${iCastName}]}].Spell.ID}
+		/varset	${NewArrayName}[1,${iCastID}] ${Me.AltAbility[${${NewArrayName}[1,${iCastName}]}].ID}
+		/varset	${NewArrayName}[1,${iSpellType}] ${Me.AltAbility[${${NewArrayName}[1,${iCastName}]}].Spell.SpellType}	
+	
+	} else /if (${${NewArrayName}[1,${iCastType}].Equal[Spell]}) {
+		|SPELL INFORMATION
+		/varset	${NewArrayName}[1,${iTargetType}] ${Spell[${${NewArrayName}[1,${iCastName}]}].TargetType}
+		/varset	${NewArrayName}[1,${iDuration}] ${Spell[${${NewArrayName}[1,${iCastName}]}].Duration}	
+		/varset	${NewArrayName}[1,${iRecastTime}] ${Spell[${${NewArrayName}[1,${iCastName}]}].RecastTime}	
+		/varset	${NewArrayName}[1,${iRecoveryTime}] ${Spell[${${NewArrayName}[1,${iCastName}]}].RecoveryTime}	
+		/varset	${NewArrayName}[1,${iMyCastTime}] ${Spell[${${NewArrayName}[1,${iCastName}]}].MyCastTime}	
+		/if (${Spell[${${NewArrayName}[1,${iCastName}]}].AERange} > 0 && ${Spell[${${NewArrayName}[1,${iCastName}]}].MyRange} == 0) {
+			/varset	${NewArrayName}[1,${iMyRange}] ${Spell[${${NewArrayName}[1,${iCastName}]}].AERange}
+		} else {
+			/varset	${NewArrayName}[1,${iMyRange}] ${Spell[${${NewArrayName}[1,${iCastName}]}].MyRange}
+		}			
+		/varset ${NewArrayName}[1,${iMana}] ${Spell[${${NewArrayName}[1,${iCastName}]}].Mana}
+		/varset	${NewArrayName}[1,${iSpellName}] ${Spell[${${NewArrayName}[1,${iCastName}]}]}
+		/varset	${NewArrayName}[1,${iSpellID}] ${Spell[${${NewArrayName}[1,${iCastName}]}].ID}
+		/varset	${NewArrayName}[1,${iCastID}] ${Spell[${${NewArrayName}[1,${iCastName}]}].ID}
+		/varset	${NewArrayName}[1,${iSpellType}] ${Spell[${${NewArrayName}[1,${iCastName}]}].SpellType}
+	
+	} else /if (${${NewArrayName}[1,${iCastType}].Equal[Disc]}) {
+		|DISC INFORMATION
+		/varset	${NewArrayName}[1,${iDuration}] ${Spell[${${NewArrayName}[1,${iCastName}]}].Duration}
+		/if (${Spell[${${NewArrayName}[1,${iCastName}]}].AERange} > 0) {
+			/varset	${NewArrayName}[1,${iMyRange}] ${Spell[${${NewArrayName}[1,${iCastName}]}].AERange}
+		} else {
+			/varset	${NewArrayName}[1,${iMyRange}] ${Spell[${${NewArrayName}[1,${iCastName}]}].MyRange}
+		}
+		/varset	${NewArrayName}[1,${iSpellName}] ${Spell[${${NewArrayName}[1,${iCastName}]}]}
+		/varset	${NewArrayName}[1,${iSpellID}] ${Spell[${${NewArrayName}[1,${iCastName}]}].ID}
+		/varset	${NewArrayName}[1,${iCastID}] ${Spell[${${NewArrayName}[1,${iCastName}]}].ID}
+	
+	
+	}
+
+	| get CheckForID
+	/if (${Bool[${AltAbility[${${NewArrayName}[1,${iCheckFor}]}].Spell}]}) {
+		/varset ${NewArrayName}[1,${iCheckForID}] ${AltAbility[${${NewArrayName}[1,${iCheckFor}]}].Spell.ID}
+	} else /if (${Bool[${Spell[${${NewArrayName}[1,${iCheckFor}]}].ID}]}) {
+		/varset ${NewArrayName}[1,${iCheckForID}] ${Spell[${${NewArrayName}[1,${iCheckFor}]}].ID}
+	} else {
+		/varset ${NewArrayName}[1,${iCheckForID}] -1
+	}
+
+
+	|Print out debug information if requsted
+	/if (${printAll} || ${printMin} || ${isHealArray}) {
+
+		/if (${printAll} || ${printMin}) /echo CastName ${${NewArrayName}[1,${iCastName}]}
+		/if (${printAll}  || ${printMin}) /echo CastType ${${NewArrayName}[1,${iCastType}]}
+		/if (${printAll}) /echo TargetType ${${NewArrayName}[1,${iTargetType}]}
+		/if (${printAll}|| ${printMin}) /echo SpellGem ${${NewArrayName}[1,${iSpellGem}]}
+		/if (${printAll}|| ${printMin}) /echo HealPct ${${NewArrayName}[1,${iHealPct}]}
+		/if (${printAll}) /echo SubToRun ${${NewArrayName}[1,${iSubToRun}]}
+		/if (${printAll}) /echo GiveUpTimer ${${NewArrayName}[1,${iGiveUpTimer}]}
+		/if (${printAll}) /echo MaxTries ${${NewArrayName}[1,${iMaxTries}]}
+		/if (${printAll}) /echo CheckFor ${${NewArrayName}[1,${iCheckFor}]}
+		/if (${printAll}) /echo MinMana ${${NewArrayName}[1,${iMinMana}]}
+		/if (${printAll}) /echo MaxMana ${${NewArrayName}[1,${iMaxMana}]}
+		/if (${printAll}) /echo MinHP ${${NewArrayName}[1,${iMinHP}]}
+		/if (${printAll}) /echo Reagent ${${NewArrayName}[1,${iReagent}]}
+		/if (${printAll}) /echo NoBurn ${${NewArrayName}[1,${iNoBurn}]}
+		/if (${printAll}) /echo NoAggro ${${NewArrayName}[1,${iNoAggro}]}
+		/if (${printAll}) /echo Mode ${${NewArrayName}[1,${iMode}]}	
+		/if (${printAll}) /echo Rotate ${${NewArrayName}[1,${iRotate}]}	
+		/if (${printAll}) /echo Delay ${${NewArrayName}[1,${iDelay}]}	
+		/if (${printAll}) /echo GiftOfMana ${${NewArrayName}[1,${iGiftOfMana}]}
+		/if (${printAll}) /echo PctAggro ${${NewArrayName}[1,${iPctAggro}]}
+		/if (${printAll}) /echo Zone ${${NewArrayName}[1,${iZone}]}
+		/if (${printAll}) /echo Zone ${${NewArrayName}[1,${iMinSick}]}
+		/if (${printAll}) /echo AllowSpellSwap ${${NewArrayName}[1,${iAllowSpellSwap}]}	
+		/if (${printAll}) /echo NoEarlyRecast ${${NewArrayName}[1,${iNoEarlyRecast}]}
+		/if (${printAll}) /echo NoStack ${${NewArrayName}[1,${iNoStack}]}
+		/if (${printAll}) /echo TriggerSpell ${${NewArrayName}[1,${iTriggerSpell}]}
+		|This print is an oddball, had to leave it back in the setting of the variable
+		|as it does some argument parsing to get it and the result is
+		/if (${printAll}) {
+			/if (${${NewArrayName}[1,${iIfs}]}) {
+				/echo Ifs always TRUE
+			} 	
+		}
+		/if (${printAll}) /echo MinEnd ${${NewArrayName}[1,${iMinEnd}]}
+		/if (${printAll}  || ${printMin}) /echo SpellDuration ${${NewArrayName}[1,${iDuration}]}
+		/if (${printAll}|| ${printMin}) /echo RecastTime ${${NewArrayName}[1,${iRecastTime}]}
+		/if (${printAll}) /echo RecoveryTime ${${NewArrayName}[1,${iRecoveryTime}]}
+		/if (${printAll} || ${printMin}) /echo ${NewArrayName} 1  MyCastTime ${${NewArrayName}[1,${iMyCastTime}]}
+		/if (${printAll}) /echo MyRange ${${NewArrayName}[1,${iMyRange}]}
+		/if (${printAll}) /echo Mana ${${NewArrayName}[1,${iMana}]}
+		/if (${printAll}) /echo ItemMustEquip ${${NewArrayName}[1,${iItemMustEquip}]}
+		/if (${printAll}) /echo SpellName ${${NewArrayName}[1,${iSpellName}]}
+		/if (${printAll}) /echo SpellID ${${NewArrayName}[1,${iSpellID}]}
+		/if (${printAll}) /echo iCastID ${${NewArrayName}[1,${iCastID}]}
+		/if (${printAll}) /echo ${${NewArrayName}[1,${iCastName}]} ${${NewArrayName}[1,${iCheckFor}]} iCheckForID ${${NewArrayName}[1,${iCheckForID}]}
+		/if (${printAll}) /echo SpellType ${${NewArrayName}[1,${iSpellType}]}
+		/if (${printAll}) /echo CastTarget ${${NewArrayName}[1,${iCastTarget}]}
+		/if (${printAll}|| ${printMin}) /echo BeforeSpell: ${${NewArrayName}[1,${iBeforeSpell}]}
+		/if (${printAll}|| ${printMin}) /echo AfterSpell: ${${NewArrayName}[1,${iAfterSpell}]}
+		/if (${printAll}) /echo ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+							
+	}
+	/if (${printMin}) {
+		/varset printMin false
+	}
+	
+	
+
+/return 
 SUB BuildSpellArrayBase(ArrayName, NewArrayName, SkipParams)
 	
 	/if (${Debug}) /echo Array ${ArrayName} ${NewArrayName}
@@ -370,6 +595,8 @@ SUB BuildSpellArrayBase(ArrayName, NewArrayName, SkipParams)
 		/varset ${NewArrayName}[${i},${iMinHP}] 70
 		/varset	${NewArrayName}[${i},${iZone}] All
 		/varset ${NewArrayName}[${i},${iIfs}] TRUE
+		/varset ${NewArrayName}[${i},${iBeforeSpell}]  
+		/varset ${NewArrayName}[${i},${iAfterSpell}]  
 		|don't need to set int values of 0 which are default for ints
 		|/varset ${NewArrayName}[${i},${iMinEnd}] 0
 		|default casting while invis to 0 which impies no casting while invis
@@ -390,6 +617,18 @@ SUB BuildSpellArrayBase(ArrayName, NewArrayName, SkipParams)
 			/if (${${ArrayName}[${i}].Find[/Gem|]}) {
 				/call argueString Gem| "${${ArrayName}[${i}]}"
 				/varset ${NewArrayName}[${i},${iSpellGem}] ${c_argueString}
+			}
+			| get AfterSpell
+			/if (${${ArrayName}[${i}].Find[/AfterSpell|]}) {
+				/varset printMin true
+				/call argueString AfterSpell| "${${ArrayName}[${i}]}"
+				/varset ${NewArrayName}[${i},${iAfterSpell}] ${c_argueString}
+			}
+			| get BeforeSpell
+			/if (${${ArrayName}[${i}].Find[/BeforeSpell|]}) {
+				/varset printMin true
+				/call argueString BeforeSpell| "${${ArrayName}[${i}]}"
+				/varset ${NewArrayName}[${i},${iBeforeSpell}] ${c_argueString}
 			}
 			| get SubToRun
 			/if (${${ArrayName}[${i}].Find[/SubToRun|]}) {
@@ -703,10 +942,14 @@ SUB BuildSpellArrayBase(ArrayName, NewArrayName, SkipParams)
 			/if (${printAll}) /echo ${${NewArrayName}[${i},${iCastName}]} ${${NewArrayName}[${i},${iCheckFor}]} iCheckForID ${${NewArrayName}[${i},${iCheckForID}]}
 			/if (${printAll}) /echo SpellType ${${NewArrayName}[${i},${iSpellType}]}
 			/if (${printAll}) /echo CastTarget ${${NewArrayName}[${i},${iCastTarget}]}
+			/if (${printAll}|| ${printMin}) /echo BeforeSpell: ${${NewArrayName}[${i},${iBeforeSpell}]}
+			/if (${printAll}|| ${printMin}) /echo AfterSpell: ${${NewArrayName}[${i},${iAfterSpell}]}
 			/if (${printAll}) /echo ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 								
 		}
-		
+		/if (${printMin}) {
+			/varset printMin false
+		}
 	/next i
 	|/deletevar ${ArrayName}
 /RETURN	${NewArrayName}

--- a/Macros/e3 Includes/e3_Utilities.inc
+++ b/Macros/e3 Includes/e3_Utilities.inc
@@ -1091,6 +1091,8 @@ SUB TrueTarget(TargetID)
 	/if (${SpawnCount[id ${TargetID}]}) {
 			/squelch /target id ${TargetID}
 			/delay 3s ${Target.ID} == ${TargetID}
+			|turn off autofire between targets
+			/if (${Me.AutoFire}) /autofire 
 	} else {
 		/echo TrueTarget has no spawncount
 	}

--- a/Macros/e3 Includes/e3_Utilities.inc
+++ b/Macros/e3 Includes/e3_Utilities.inc
@@ -1125,7 +1125,7 @@ SUB check_macroTimers
 	/for i 1 to ${timerArray.Size}
     /if (${Defined[${timerArray[${i}]}]}) {
 		/if (!${${timerArray[${i}]}}) {
-        		/echo Deleting timer: ${timerArray[${i}]}
+        		|/echo Deleting timer: ${timerArray[${i}]}
 			    /varcalc SpentTimerCounter ${SpentTimerCounter} + 1
 				/deletevar ${timerArray[${i}]}
 				/varset SpentTimerList ${SpentTimerList}${i},

--- a/Macros/e3.mac
+++ b/Macros/e3.mac
@@ -1,7 +1,8 @@
 |---------------------------------------------------|
-|- e3.mac	v7.0				                             -|
+|- e3.mac	v8.0				                             -|
 |- Originally written by Killians of PEQ.	         -|
 |- Enhanced and maintained by Creamo of PEQ.       -|
+|- Enhanced for Laz server by Rekka and Ewiclip    -|
 |- Thanks to Vysra for IDE,additional plugins,code -|
 |---------------------------------------------------|
 |#warning
@@ -9,7 +10,7 @@
 #include e3 Includes\e3_Setup.inc
 
 SUB Main(modeSelect)
-  /declare macroVersion string outer 7.0
+  /declare macroVersion string outer 8.0
   /declare Debug bool outer false
   /declare IniMode string outer Ini
   /if (${Bool[${Plugin[MQ2IniExt]}]}) {

--- a/Macros/e3.mac
+++ b/Macros/e3.mac
@@ -55,7 +55,6 @@ SUB Main(modeSelect)
       /if (${mainLoop_IsHealer}) {
         /call check_Heals
       }
-      
       /for i 1 to ${mainLoop_Array.Size}
 				/if (${Bool[${mainLoop_Array[${i}]}]}) {
           /call ${mainLoop_Array[${i}]}

--- a/Macros/e3.mac
+++ b/Macros/e3.mac
@@ -5,7 +5,7 @@
 |- Thanks to Vysra for IDE,additional plugins,code -|
 |---------------------------------------------------|
 |#warning
-#turbo 100
+#turbo 240
 #include e3 Includes\e3_Setup.inc
 
 SUB Main(modeSelect)
@@ -22,6 +22,10 @@ SUB Main(modeSelect)
 		/delay 5
 	}
   /declare i int local
+  /declare mainLoop_IsHealer bool local False
+  /if (${Select[${Me.Class.ShortName},CLR,DRU,SHM]}) {
+    /varset mainLoop_IsHealer True
+  } 
 
 :MainLoop
 /if (${Debug}) /echo |- MainLoop ==>
@@ -42,13 +46,31 @@ SUB Main(modeSelect)
 		| If I'm not active, call mainFunctions
 		/if (!${activeTimer}) {
       |These are functions in the e3_setup/Advanced.ini class sections... ex CLR Function#1=check_DivineArb
-			/for i 1 to ${mainLoop_Array.Size}
+			
+
+      :restartMainLoopSubLoop
+      |if you are a healer, hard coding a check_heals. This is to deal with sub methods being able to call
+      |interrupts for heals and then then ActionTaken is set to true, which may never get to your check_heals
+      |all healers should have check_Heals as their #1, this is just making sure it is. 
+      /if (${mainLoop_IsHealer}) {
+        /call check_Heals
+      }
+      
+      /for i 1 to ${mainLoop_Array.Size}
 				/if (${Bool[${mainLoop_Array[${i}]}]}) {
           /call ${mainLoop_Array[${i}]}
+          /if (${castReturn.Equal[CAST_INTERRUPTED]}) {
+            /if (${mainLoop_IsHealer}) {
+              /call check_Heals
+            }
+          }
+          /varset castReturn  
           |check to see if anything has been set to try and cast without an interrupt
           /doevents nowCast
+          /varset castReturn  
 				  |check to see if we have spell(s) ready in nowCast that may have interrupted the above call
           /call castNowSpells
+          /varset castReturn  
         } 
       /if (!${ActionTaken}) /next i
 
@@ -57,25 +79,26 @@ SUB Main(modeSelect)
         /if (!${Me.Moving} && !${Following} && !${Me.Casting.ID}) {
           /if ((${Me.PctMana} < ${autoMedPctMana} && ${Me.MaxMana} > 1 && ${autoMedChar}) || (${Me.PctEndurance} < ${autoMedPctMana} && ${autoMedChar})) {
             /varset medBreak TRUE
-			/if ((${Defined[AssistType]}) && (${Select[${Me.Class.ShortName},CLR,DRU,ENC,MAG,NEC,SHM,WIZ]})) {
-			  /varset AssistType Off 
-			} else {
-			  /declare AssistType string Off
-			}
+            /if ((${Defined[AssistType]}) && (${Select[${Me.Class.ShortName},CLR,DRU,ENC,MAG,NEC,SHM,WIZ]})) {
+            /varset AssistType Off 
+            } else {
+            /declare AssistType string Off
+            }
           }
         }
       }
       /if (${medBreak}) /call check_MedBreak
 		}
 
-  /if (${MoveUtils.GM}) {
+  |**/if (${MoveUtils.GM}) {
     /squelch /stick imsafe
     /echo GM Safe kicked in, issued /stick imsafe.  you may need to reissue /followme or /assiston
-  }
+  }**|
 /if (${Debug}) {
 	/echo <== MainLoop -|
 	/delay 5
 }
+/delay 1
 /goto :MainLoop	
 /RETURN
 


### PR DESCRIPTION
Huge patch for E3. 

Core feature:

Fixed *most* item click issues. 
This took a *ton* of work, required an update to the bad players and the way most things were called inside of E3

New Features:
/BeforeSpell, /AfterSpell, these new tags can be used on nukes/heals/etc to fire off after or before a spell/item/aa is cast. The after/before must be a spell/item/aa.

Autofire is now a valid range type for ranger types to use. This will make your ranger act like a caster but they will auto shoot and face the target.  

nowCast, like queueCast but far more aggressive. 

We now have a new E3 bard player.  This takes the the place of the old "Twist" player.  the old "Twist" player has been moved to MQ2Twist. 

Updates: 
Burns updated to fire *much*  faster now.  Cleric/Druid/Shaman have kickouts so they continue healing however. (tank/xtargets)

Melody Pause/Resume now work.

When casting an item for MQ2Twist, it will now stop the song, click the item, and continue where it left off. While not ideal, it prevents the entire twist from restarting. 

Bug Fixes:
Fixed Bug in E3 concerning discs and if they were in use or not. (what helped burns out eventually)
Fixed a bug on HoT's being case not being interrupted if the tank/xtarget needed heals. 

Mostly fixed meming of spells. Were you would mem a spell... unmem, mem another spell.. repeat, this was needed for summoned items that were being cast out of combat. 

Performance: 

Performance enhancements for castSimpleSpell, which translates to most things cast in e3 since now everything uses it, that isn't one of the primary array types (dots/nukes/debuffs/heals/etc).

 
