### PR TITLE
Feature/healer loot

### DIFF
--- a/Macros/e3 Includes/e3_Assists.inc
+++ b/Macros/e3 Includes/e3_Assists.inc
@@ -126,6 +126,7 @@ SUB AssistOff
   /if (${Me.Combat})    /attack off
   /if (${Me.AutoFire})  /autofire off
   /if (${Me.Pet.ID}) /squelch /pet back off
+
   /delay 5 !${Me.Combat} && !${Me.AutoFire}
 
 	/varset Assisting FALSE
@@ -1103,7 +1104,15 @@ SUB cast_damageOverTimeSpells(int TargetID, string ArrayName)
 /for i 1 to ${${ArrayName}.Size[1]}
     /doevents DoTsOff
     |make sure we have the right target    
-   
+    |make sure we don't need to do any healing
+    /if (${mainLoop_IsHealer}) {
+       /call check_HealCasting_DuringDetrimental
+        /if (!${c_SubToRun}) {
+            /varset ActionTaken TRUE
+            /return
+        }
+    }
+
     |make sure our target is not a corpse
     /if (!${Bool[${Spawn[id ${TargetID}].Type.NotEqual[Corpse]}]}) {
       /return

--- a/Macros/e3 Includes/e3_Assists.inc
+++ b/Macros/e3 Includes/e3_Assists.inc
@@ -295,6 +295,7 @@ SUB CombatAbilities
         /if (${Select[${Spawn[id ${Target.ID}].Type},${AcceptableTargetTypes}]}) {
           /if (${Me.AbilityReady[Taunt]}) {
             /bc Taunting ${Target.CleanName}: ${Me.TargetOfTarget.Class.ShortName}-${Me.TargetOfTarget} has aggro
+            /echo [${Time}] Taunting ${Target.CleanName}: ${Me.TargetOfTarget.Class.ShortName}-${Me.TargetOfTarget} has aggro
             /doability Taunt
           |} else /if (${Me.CombatAbilityReady[Mock]}) {
           |  /bc Mock on ${Target.CleanName}: ${Me.TargetOfTarget.Class.ShortName}-${Me.TargetOfTarget} has aggro

--- a/Macros/e3 Includes/e3_Background.inc
+++ b/Macros/e3 Includes/e3_Background.inc
@@ -136,7 +136,7 @@ SUB check_Active
 	}
 
   |prevent guys from getting stuck trying to buff while moving
-	/if (${Me.Moving}) {
+	/if (${Me.Moving} && !${Me.Class.ShortName.Equal[BRD]}) {
 	  /if (${Me.CombatState.Equal[COMBAT]}) {
       /varset activeTimer 2
       /varset rebuffTimer 10

--- a/Macros/e3 Includes/e3_Basics.inc
+++ b/Macros/e3 Includes/e3_Basics.inc
@@ -223,8 +223,9 @@ SUB EVENT_bark(line, ChatSender, msgTarget, barkMsg)
     /delay 1s
   }
 
-  |/doevents barkReturn
-  |/if (!${barkReturned}) {
+  /doevents barkReturn
+  /delay 1s
+  | /if (!${barkReturned}) {
   |  /delay 5s    
   |}
   | -Check to see if the bark was successful.

--- a/Macros/e3 Includes/e3_Basics.inc
+++ b/Macros/e3 Includes/e3_Basics.inc
@@ -300,7 +300,7 @@ SUB EVENT_clickIt(line, ChatSender, eventParams)
     /declare clickDelay int local ${Math.Calc[${Math.Rand[${Me.ID}]}%${clickitRandomDelay}|1]}
     /declare startingLoc ${Me.Loc}
     :retryClickDoor
-    /delay ${clickDelay}
+    
     /squelch /doortarget id ${closestDoorID}
     
     |casting while zoning has been reported to cause a problem
@@ -310,6 +310,8 @@ SUB EVENT_clickIt(line, ChatSender, eventParams)
       /stopcast
     }
     /squelch /click left door
+    |give time for the click and zoning to take place.
+    /delay ${clickDelay}
     /if (${MyZone}==${Zone.ID} && ${Math.Distance[${startingLoc}]} < 10) {
       /if (${clickTimer}) {
         /goto :retryClickDoor

--- a/Macros/e3 Includes/e3_Basics.inc
+++ b/Macros/e3 Includes/e3_Basics.inc
@@ -181,7 +181,7 @@ SUB EVENT_bark(line, ChatSender, msgTarget, barkMsg)
   /varset barkTarget ${Spawn[id ${msgTarget}].CleanName}
   /varset barkReturned FALSE
 
-  /declare retryTimer timer local 15s
+  /declare retryTimer timer local 3s
   /declare startingLoc string local
 
   /if (${Spawn[id ${msgTarget}].Distance}>${MaxResponseDist}) {
@@ -195,7 +195,8 @@ SUB EVENT_bark(line, ChatSender, msgTarget, barkMsg)
 
   /doevents barkReturn flush
 
-  :retry_Bark
+  /declare barkStartZone int ${Zone.ID}
+
   /if (${Me.Invis}) /makemevisible
   /call TrueTarget ${msgTarget}
   /if (${Target.Distance} > 5) /call MoveToLoc ${Target.Y} ${Target.X} 50 5
@@ -208,11 +209,11 @@ SUB EVENT_bark(line, ChatSender, msgTarget, barkMsg)
     /varset barkMsg ${c_eventArgData.Arg[1,-]}
     /varset barkMsg ${c_eventArgData.Left[${Math.Calc[${c_eventArgData.Length} - 1].Int}]}
   }
-
+  :retry_Bark
   /say ${barkMsg}
   | -Wait up to 2 seconds for something to happen.
-  /delay 2s ${Zone.ID} != ${currentZone} || ${Me.Loc.Replace[ ,].NotEqual[${startingLoc}]} || ${Window[ConfirmationDialogBox].Open} || ${Window[LargeDialogWindow].Open}
-
+  |/delay 1s ${Zone.ID} != ${currentZone} || ${Me.Loc.Replace[ ,].NotEqual[${startingLoc}]} || ${Window[ConfirmationDialogBox].Open} || ${Window[LargeDialogWindow].Open}
+  /delay 1s
   | -Click Yes to a confirmation box.
   /if (${Window[ConfirmationDialogBox].Open}) {
     /notify ConfirmationDialogBox Yes_Button leftmouseup
@@ -222,15 +223,21 @@ SUB EVENT_bark(line, ChatSender, msgTarget, barkMsg)
     /delay 1s
   }
 
-  /doevents barkReturn
+  |/doevents barkReturn
+  |/if (!${barkReturned}) {
+  |  /delay 5s    
+  |}
   | -Check to see if the bark was successful.
-  /if (${Zone.ID} == ${currentZone} && ${Math.Distance[${startingLoc}]} < 8 && !${barkReturned}) {
+  /if (${Zone.ID} == ${barkStartZone} && ${Math.Distance[${startingLoc}]} < 8 && !${barkReturned}) {
+    /echo Retrying. ${Zone.ID} == ${barkStartZone} && ${Math.Distance[${startingLoc}]} < 8 && !${barkReturned}
     /if (${retryTimer}) {
       /goto :retry_Bark
     } else {
       /docommand ${ChatToggle} Nothing seems to have happened...
     }
   }
+  /varset barkReturned False
+
 /if (${Debug} || ${Debug_Basics}) /echo <== EVENT_Bark -|
 /RETURN
 

--- a/Macros/e3 Includes/e3_Basics.inc
+++ b/Macros/e3 Includes/e3_Basics.inc
@@ -112,6 +112,7 @@ SUB EVENT_Stop(line, ChatSender)
     /if (${line.Find[,]}) /varset line ${line.Left[${Math.Calc[${line.Find[,]}-1]}]} ${line.Right[-${line.Find[,]}]}
     /if (!${checkEventArgs[${ChatSender},${line},UZR]}) /return
       | -Wait to get close to the followTarget.
+    /echo [${Time}] Delaying up to 1 second(s) in EVENT_Stop
     /delay 1s ${Spawn[${FollowTarget}].Distance} < 25
     | -Stop following
     /if (${Stick.Active}) /squelch /stick off
@@ -431,6 +432,7 @@ SUB EVENT_runThruZone(line, ChatSender, eventParams)
       /delay 2
       /keypress forward hold
       | -Wait to zone.
+      /echo [${Time}] Delaying up to 6 seconds in EVENT_runThruZone
       /delay 6s !${Zone.ID} || ${Zone.ID} != ${startZone}
       | -Check if I zoned.
       /if (${Zone.ID} == ${startZone}) {
@@ -955,8 +957,10 @@ SUB EVENT_Swap_Items(line, IniEntry)
 	} else {
 		/if (${Cursor.ID}) /call ClearCursor
 		/if (${Bool[${Me.Casting}]} && ${Me.Class.ShortName.NotEqual[BRD]}) {
+      /echo [${Time}] Delaying up to 3 seconds in EVENT_Swap_Items
 		  /delay 3s !${Me.Casting.ID}
       /call interrupt
+      /echo [${Time}] Delaying up to 3 seconds in EVENT_Swap_Items
       /delay 3s !${Me.Casting.ID}
     }
 		/declare i int local 1
@@ -1240,13 +1244,15 @@ SUB EVENT_Invite(line, ChatSender)
   /if (!${checkEventArgs[${ChatSender},${line},U,""]}) /return
   /if (${Me.Casting.ID} && ${Me.Class.ShortName.NotEqual[BRD]}) {
     /call interrupt
-    /delay 5s !${Me.Casting.ID}
+    /echo [${Time}] Delaying up to 5 seconds in EVENT_Invite
+    /delay 5s !${Window[CastingWindow].Open}
   }
   /declare retryTimer timer local 5s
   :retry_Invite
   /squelch /target clear
   /delay 3
   /invite
+  /echo [${Time}] Delaying up to 1 second(s) in EVENT_Invite
   /delay 1s ${Bool[${Group}]}
   /if (!${Bool[${Group}]}) {
     /if (${retryTimer}) {
@@ -1301,9 +1307,11 @@ SUB EVENT_saveGroup(line, ChatSender, eventParams)
         }
       }
     } else {
+      /echo [${Time}] Delaying up to 2 second(s) in EVENT_saveGroup
       /delay 2s
     }
     | Delay for a moment to allow other bots to catch up, so they don't overwrite our soon to be saved group.
+    /echo [${Time}] Delaying up to 2.5 second(s) in EVENT_saveGroup
     /delay ${Math.Rand[25]}
     | Save the group configuration
     /echo Group configuration(s) saved. Use [/group ${groupName}] to recall this group setup.
@@ -1387,6 +1395,7 @@ SUB EVENT_groupUp(line, ChatSender, createGroup)
     | check to see if I am the group leader(GroupMember#0)
     /if (${${IniMode}[${Group_Ini},${${IniMode}[${Group_Ini}].Arg[${i},|]},GroupMember#0].Equal[${Me.CleanName}]}) {
       /echo Recalling [${groupName}]...
+      /echo [${Time}] Delaying up to 1.5 second(s) in EVENT_groupUp
       /delay 15
       | Invite group members while ignoring placeholders, and set
       /for e 1 to 5
@@ -1397,7 +1406,7 @@ SUB EVENT_groupUp(line, ChatSender, createGroup)
         /invite ${groupMembers[${e}]}
       }
       /next e
-
+      /echo [${Time}] Delaying up to 8 second(s) in EVENT_groupUp
       /delay 8s ${Group} == ${groupSize}
       /if (${Group} != ${groupSize}) {
         /for e 1 to 5
@@ -1761,7 +1770,8 @@ sub event_gimme(line, ChatSender, RequestedItem)
 	| check if the requestor can be reached
 	/if (!${Spawn[${ChatSender}].LineOfSight}) {
 		/call notifyViaBCTell  ${ChatSender} "Where are you? I don't see you. Please move closer if you want me to give you something."
-		/delay 10
+	  /echo [${Time}] Delaying up to 1 second(s) in event_gimme
+  	/delay 10
 		/return
 	}	
 	
@@ -1783,16 +1793,22 @@ sub event_gimme(line, ChatSender, RequestedItem)
 		/echo Collecting Diamond Coins to give to ${ChatSender}
 		/delay 1
 		/if (${Window[InventoryWindow].DoOpen}) /echo Inventory Window Open
+    /echo [${Time}] Delaying up to 5 second(s) in event_gimme
 		/delay 5s ${Window[InventoryWindow].Open}
 		/notify InventoryWindow IW_Subwindows tabselect 5
+     /echo [${Time}] Delaying up to 1 second(s) in event_gimme
 		/delay 1s
 		/notify InventoryWindow AltCurr_PointList listselect 8
+     /echo [${Time}] Delaying up to 1 second(s) in event_gimme
 		/delay 1s
 		/notify InventoryWindow IW_AltCurr_ReclaimButton leftmouseup
+     /echo [${Time}] Delaying up to 1 second(s) in event_gimme
 		/delay 1s
 		/notify InventoryWindow IW_AltCurr_CreateItemButton leftmouseup
+     /echo [${Time}] Delaying up to 1 second(s) in event_gimme
 		/delay 1s
 		/notify QuantityWnd QTYW_Accept_Button leftmouseup
+    /echo [${Time}] Delaying up to 3 second(s) in event_gimme
 		/delay 3s ${Bool[${Cursor.ID}]}
 		/if (${Window[InventoryWindow].Child[IW_AltCurrPage].Open}) /if (${Window[InventoryWindow].DoClose}) /echo Inventory Window Closed
 	} else /if (${IsMyBot} && (${RequestedItem.Equal[platinum]} || ${RequestedItem.Equal[pp]} || ${RequestedItem.Equal[plat]})) {
@@ -1801,10 +1817,13 @@ sub event_gimme(line, ChatSender, RequestedItem)
 			/echo Collecting Plat to give to ${ChatSender}
 			/delay 1
 			/if (${Window[InventoryWindow].DoOpen}) /echo Inventory Window Open
+      /echo [${Time}] Delaying up to 5 second(s) in event_gimme
 			/delay 5s ${Window[InventoryWindow].Open}
 			/notify InventoryWindow IW_Money0 leftmouseup
+      /echo [${Time}] Delaying up to 1 second(s) in event_gimme
 			/delay 1s
 			/notify QuantityWnd QTYW_Accept_Button leftmouseup
+      /echo [${Time}] Delaying up to 1 second(s) in event_gimme
 			/delay 1s
 			/varset platOnCursor true
 		} else {
@@ -1818,15 +1837,19 @@ sub event_gimme(line, ChatSender, RequestedItem)
 		/if (${DebugGimme}) /echo IsMyBot = ${IsMyBot}		
 		/if (${IsNoRent} || ${IsMyBot}) {
 			/ItemNotify "${RequestedItem}" leftmouseup
+      /echo [${Time}] Delaying up to 2 second(s) in event_gimme
 			/delay 2s ${Bool[${Cursor.ID}]}
 		} else {
+      /echo [${Time}] Delaying up to 2 second(s) in event_gimme
 			/delay 2s
 			/tell ${ChatSender} Only temporary items can be requested
 			/return
 		}
 	} else /if (${Bool[${FindItem[=Summoned: ${RequestedItem}]}]}) {
 		/ItemNotify "Summoned: ${RequestedItem}" leftmouseup
+    /echo [${Time}] Delaying up to 3 second(s) in event_gimme
 		/delay 3s ${Bool[${Cursor.ID}]}
+    /echo [${Time}] Delaying up to 1 second(s) in event_gimme
     /delay 1s
 		
 	} else {
@@ -1838,6 +1861,7 @@ sub event_gimme(line, ChatSender, RequestedItem)
 		/echo ${RequestedItem}
 		/if (${IsRequestedItemModShard}) {
       /bc A request for Modulation shards has been made, please pause for a moment.
+      /echo [${Time}] Delaying up to 1 second(s) in event_gimme
       /delay 2s
       /bc Deleting old Mulation Shards, watch your cursor.
 			|get rid of old mod rods, to remote then local
@@ -1896,7 +1920,9 @@ sub event_gimme(line, ChatSender, RequestedItem)
 		}
 		/if (${SummoningItem}) {
         |we delay 1 sec after cusror id says it has something due to timing issues
+        /echo [${Time}] Delaying up to 15 second(s) in event_gimme
         /delay 15s ${Bool[${Cursor.ID}]}
+        /echo [${Time}] Delaying up to 1 second(s) in event_gimme
         /delay 1s
 
     } 
@@ -1919,6 +1945,7 @@ sub event_gimme(line, ChatSender, RequestedItem)
 		
     /Echo Gimmie: Getting target of requester
     /target pc ${ChatSender}
+    /echo [${Time}] Delaying up to 10 second(s) in event_gimme
     /delay 10s ${Target.ID}==${Spawn[${ChatSender}].ID}
 
     /declare originalLoc string local ${Me.Loc}
@@ -1926,17 +1953,20 @@ sub event_gimme(line, ChatSender, RequestedItem)
 		/stick 12
 		/while (${Math.Distance[${Spawn[${ChatSender}].Loc}]}>20) {
 			/if (${Debug}) /echo Distance = ${Math.Distance[${senderLoc}]}
+      /echo [${Time}] Delaying up to 1 second(s) in event_gimme
 			/delay 1s
 		}
 		/if (${DebugGimme}) /echo Distance = ${Math.Distance[${senderLoc}]}
 		/if (${DebugGimme}) /echo IsClose = ${Bool[${Math.Distance[${senderLoc}]}<20]}
 		/click left target
+    /echo [${Time}] Delaying up to 3 second(s) in event_gimme
 		/delay 3s ${Window[TradeWnd].Open}
 		/declare tradeTries int local 0
 		/while (${Window[TradeWnd].Open} && ${tradeTries} < 2) {
 			/notify TradeWnd TRDW_Trade_Button leftmouseup 
 			/delay 5
 			/bct ${Target.CleanName} //notify TradeWnd TRDW_Trade_Button leftmouseup 
+      /echo [${Time}] Delaying up to 1 second(s) in event_gimme
 			/delay 1s
 			/varset tradeTries ${Math.Calc[${tradeTries} + 1]}
       /echo tradeTries=${tradeTries}
@@ -2030,6 +2060,7 @@ SUB check_Gimme
 					}
 					/varset GimmeTimer${i} ${gimmeTimeout}
 					| Minimum of 10s delay between requests
+          /echo [${Time}] Delaying up to 10 second(s) in check_Gimme
 					/delay 10s
 					/return
 				}
@@ -2104,10 +2135,12 @@ SUB check_Supply
 				/if (${supplyItem.Find[Modulation Shard]}) {
             |get rid of old mod rods, to remote then local
             /bc A request for Modulation shards has been made, please pause for a moment. Starting in 4 seconds
+            /echo [${Time}] Delaying up to 4 second(s) in check_Supply
             /delay 4s
             /bc Deleting old Mulation Shards, watch your cursor.
             /bca ItemDeleteSummoned ${supplyItem}
             /call ItemDeleteSummoned "${supplyItem}"
+            /echo [${Time}] Delaying up to 2 second(s) in check_Supply
             /delay 2s
 				}
 
@@ -2128,8 +2161,10 @@ SUB check_Supply
               /call castSimpleSpellBase "${supplySpell}/Gem|${supplyGem}" ${Me.ID} False
            }
 				}
+        /echo [${Time}] Delaying up to 20 second(s) in check_Supply
 				/delay 20s ${Cursor.ID}
         /call ClearCursor
+        /echo [${Time}] Delaying up to 1 second(s) in check_Supply
         /delay 1s
   		  
 				| If the item is a modulation shard, tell everyone to put it in their bag
@@ -2143,6 +2178,7 @@ SUB check_Supply
       	}
 				| Memorize the previous spell if needed
 				/if (${Bool[${previousSpell}]}) {
+          /echo [${Time}] Delaying up to 1 second(s) in check_Supply
 					/delay 1s
 					/echo ==> Supply: Memorizing ${previousSpell} to gem ${supplyGem}.
 					/call memorize_spell "${previousSpell}" "${supplyGem}"
@@ -2177,6 +2213,7 @@ SUB event_collect(line, ChatSender, RequestedItem)
     /declare i int local
     /for i 1 to ${Group.Members}
       /t ${Group.Member[${i}]} Gimme ${RequestedItem}
+      /echo [${Time}] Delaying up to 4 second(s) in event_collect
       /delay 4s
     /next i 
   }
@@ -2574,9 +2611,11 @@ SUB check_Forage
     /if (${ForageOn} && ${Me.AbilityReady[Forage]} && !${medBreak} && !${Me.CombatState.Equal[DEBUFFED]} && !${Me.Invis} && (${Me.MaxMana} == 0 || ${Me.PctMana} == 100) && ${Me.PctHPs} == 100 && ${Me.PctAggro} < 1 && !${Me.CombatState.Equal[COMBAT]} && !${Assisting}) {   
 		/echo == Foraging ==
 		/doability forage
+    /echo [${Time}] Delaying up to 2 second(s) in check_Forage
 		/delay 2s ${Bool[${Cursor.ID}]}
 		/while (${Bool[${Cursor.ID}]}) {
 			/call ClearCursor
+       /echo [${Time}] Delaying up to 1 second(s) in check_Forage
 			/delay 1s
 		}
 	}
@@ -2617,13 +2656,16 @@ SUB ItemDeleteSummoned(ItemString)
         } 
         /echo Trying to Deleting ${ItemString}
         /call ClearCursor
+        /echo [${Time}] Delaying up to 1 second(s) in ItemDeleteSummoned
         /delay 1s
         |Found the issue of char disconnect. If you try and do a leftmouse up on an item and your casting
         |the server will disconnect you. So doing this out of bound of E3's event loop is dangerous
-        /while (${Cast.Status.Find[C]}) {
+        /while (${Window[CastingWindow].Open}) {
+          /echo [${Time}] Delaying up to 1 second(s) in ItemDeleteSummoned
           /delay 1
         }
         /itemnotify "${ItemString}" leftmouseup
+        /echo [${Time}] Delaying up to 10 second(s) in ItemDeleteSummoned
         /delay 10s ${Bool[${Cursor.ID}]}
         /if (${Bool[${Cursor.ID}]} &&  ${Cursor.Name.Find[Summoned:]}) /destroy
 

--- a/Macros/e3 Includes/e3_BuffCheck.inc
+++ b/Macros/e3 Includes/e3_BuffCheck.inc
@@ -284,6 +284,7 @@ SUB checkAuras
       /if (${c_Ready}) {
         /if (${check_Mana["auraSpells2D",1]}) {
           /call e3_Cast ${Me.ID} "auraSpells2D" "1"
+          /echo [${Time}] Delaying up to 7 seconds in checkAuras
           /delay 7s !${Me.Casting.ID}
         }
       }

--- a/Macros/e3 Includes/e3_BuffCheck.inc
+++ b/Macros/e3 Includes/e3_BuffCheck.inc
@@ -3,11 +3,13 @@
 |--------------------------------------------------------------------------------|
 SUB check_Buffs
 	/if (${Debug} || ${Debug_BuffCheck}) /echo |- buffCheck ==>
-  	/if (${BuffCheck} && !${ActionTaken} && !${activeTimer} && !${rebuffTimer}) {
+  	
+    /if (${Defined[InstantBuffs2D]})		/call buffBotsInstant "InstantBuffs2D"
+    /if (${BuffCheck} && !${ActionTaken} && !${activeTimer} && !${rebuffTimer}) {
 		/if (!${idle} && ${BuffCombatCheck} && !${Me.Moving} && ${Assisting})	/call buffBots "CombatBuffs2D"
 		/if (${procBuff} && !${idle} && !${Me.Moving} && ${Assisting}) /call buffProcs
 		/if (${Defined[auraSpells2D]} && (${auraCombat} || ${Me.CombatState.NotEqual[COMBAT]}) && !${Me.Moving}) /call checkAuras
-		/if (${Defined[InstantBuffs2D]})		/call buffBots "InstantBuffs2D"
+		
 		/if (!${combatTimer} && ${Me.CombatState.NotEqual[COMBAT]} && !${Assisting} && !${Me.Moving} && ${BuffCheck}) {
 			/if (${Defined[SelfBuffs2D]}) /call buffBots "SelfBuffs2D"
 			/if (${Defined[BotBuffs2D]})	/call buffBots "BotBuffs2D"
@@ -22,6 +24,61 @@ SUB check_Buffs
 |- Cast and maintain buffs on a NetBot or NetBot's Pet.	-|
 |- the space after ${buffSpellID} is important "Find[${buffSpellID} ]"
 |----------------------------------------|
+
+sub buffBotsInstant(ArrayName)
+/if (${Debug} || ${Debug_BuffCheck}) /echo |- buffBotsInstant [${ArrayName}] ==>
+	/declare s					int local
+	/declare buffTargetID		int local
+	/declare buffTarget			string local
+	/declare buffSpellID		int local
+	/declare buffCheckForID		int local	
+	/declare buffSpellName		string local
+	/declare buffCheckForName	string local
+	/declare currentBuffs		string local
+	/declare currentSongs		string local
+
+ /for s 1 to ${${ArrayName}.Size[1]}
+	/if (${Debug} || ${Debug_BuffCheck}) /echo buffing ${${ArrayName}[${s},${iCastName}]} on ${${ArrayName}[${s},${iCastTarget}]} checkFor ${${ArrayName}[${s},${iCheckFor}]}
+
+  /varset buffTargetID ${Me.ID}
+  /varset buffTarget ${Me.Name}
+
+	/varset buffSpellName		${${ArrayName}[${s},${iSpellName}]}
+	/varset buffSpellID			${${ArrayName}[${s},${iSpellID}]}]
+	/varset buffCheckForName	${${ArrayName}[${s},${iCheckFor}]}
+	/varset buffCheckForID		${${ArrayName}[${s},${iCheckForID}]}
+		
+  /if (!${Bool[${NetBots[${buffTarget}].ID}]}) {
+     /goto :skipBuff
+  } 
+
+  /if (${Select[${buffSpellID},8001,8002,8000,8003]}) {
+    /call meleeCombatBuffs "${ArrayName}" ${s}
+    /goto :skipBuff
+  }
+
+  |------- Self ------|
+    /if (!${Bool[${Me.Buff[${buffSpellName}]}]} || (${Bool[${Me.Buff[${buffSpellName}]}]} && ${Me.Buff[${buffSpellName}].Duration.TotalSeconds} <= ${buffRecastTime})) {
+    /if (!${Bool[${Me.Song[${buffSpellName}]}]} && !${Bool[${Me.Song[${buffCheckForName}]}]}) {
+      /if (${Spell[${buffSpellID}].NewStacks} && !${Bool[${Me.Buff[${buffCheckForName}]}]}) {
+        /call check_Ready "${ArrayName}" ${s}
+        /if (${c_Ready} && ${${ArrayName}[${s},${iIfs}]}) {
+          /if (${check_Mana["${ArrayName}",${s}]}) {
+            /call e3_Cast ${buffTargetID} "${ArrayName}" ${s}
+          }
+        } 
+      }
+    }
+  }
+ 
+  :skipBuff
+ /next s
+
+ /if (${Debug} || ${Debug_BuffCheck}) /echo <== buffBotsInstant -|
+
+/return
+
+
 SUB buffBots(ArrayName)
 /if (${Debug} || ${Debug_BuffCheck}) /echo |- buffBots [${ArrayName}] ==>
 	/declare s					int local

--- a/Macros/e3 Includes/e3_Casting.inc
+++ b/Macros/e3 Includes/e3_Casting.inc
@@ -134,16 +134,17 @@ Sub e3_Cast(int targetID, ArrayName, int ArrayIndex, bool StopEchos)
 	|CatchAll Function for potentially locked up spell gems.
   	/call check_SpellGemLockup
 
-	/declare beforeSpell string local ${${ArrayName}[${ArrayIndex},${iBeforeSpell}]}
-	/if (${beforeSpell.Length}>1) {
-		/echo BeforeCast configured, calling "${beforeSpell}"
-		/call CastAfterBeforeSpell "${beforeSpell}"
-	}
 	/declare beforeEvent string local ${${ArrayName}[${ArrayIndex},${iBeforeEvent}]}
 	/if (${beforeEvent.Length}>1) {
 		/echo BeforeEvent configured, calling "${beforeEvent}"
 		/docommand ${beforeEvent}
 	}
+	/declare beforeSpell string local ${${ArrayName}[${ArrayIndex},${iBeforeSpell}]}
+	/if (${beforeSpell.Length}>1) {
+		/echo BeforeCast configured, calling "${beforeSpell}"
+		/call CastAfterBeforeSpell "${beforeSpell}"
+	}
+
 	
 	
 	
@@ -693,7 +694,7 @@ Sub check_Ready(ArrayName, int ArrayIndex)
 
 		}
 	} 
-	/if (${Me.ItemReady[=${${ArrayName}[${ArrayIndex},${iCastName}]}]}) {
+	/if (${Me.ItemReady[${${ArrayName}[${ArrayIndex},${iCastName}]}]}) {
 		/varset c_Ready TRUE
 	} 
   

--- a/Macros/e3 Includes/e3_Casting.inc
+++ b/Macros/e3 Includes/e3_Casting.inc
@@ -774,6 +774,8 @@ Sub check_ReadySimple(spellName, gemToUse)
 Sub memorize_spell(spellName,gemNum)
   /if (${Debug} || ${Debug_Casting}) /echo |- memorize_spell =>
   	/memorize "${spellName}" ${gemNum}
+
+	 /echo [${Time}] Delaying up to 5 seconds in memorize_spell
 	/delay 5s ${Bool[${Me.Gem[${spellName}]}]}
 	
 	|only wait for beneficial,self spells
@@ -787,7 +789,7 @@ Sub memorize_spell(spellName,gemNum)
 	|/echo wfr ${waitForReady} rc ${Spell[${spellName}].RecastTime} math ${Math.Calc[25+(${Spell[${spellName}].RecastTime}/100)]}
 	:checkTimer
 		
-		|/echo chectimer ${waitForReady} ${Me.SpellReady[${spellName}]}
+	/echo [${Time}] Delaying waiting for spell to memorize and to be ready in memorize_spell
 	/if (${waitForReady}) {
 		/doevents Follow
 		/doevents Stop

--- a/Macros/e3 Includes/e3_Casting.inc
+++ b/Macros/e3 Includes/e3_Casting.inc
@@ -678,7 +678,14 @@ Sub check_Ready(ArrayName, int ArrayIndex)
     /if (!${Bool[${Me.Gem[${${ArrayName}[${ArrayIndex},${iCastName}]}]}]}) {
  		/call memorize_spell "${${ArrayName}[${ArrayIndex},${iCastName}]}" ${${ArrayName}[${ArrayIndex},${iSpellGem}]}
 	}
-	/if (${Me.SpellReady[${${ArrayName}[${ArrayIndex},${iCastName}]}]}) /varset c_Ready TRUE
+
+	/if ((${Bool[${Me.Gem[Focused Hail of Arrows]}]}  &&  ${Bool[${Me.Gem[Hail of Arrows]}]}) && (${${ArrayName}[${ArrayIndex},${iCastName}].Equal[Focused Hail of Arrows]} || ${${ArrayName}[${ArrayIndex},${iCastName}].Equal[Hail of Arrows]})) {
+		|spell hard coded as me.spelready returns true when one is on cooldown because of a timer of another.
+		/varset c_Ready TRUE
+		/if (!${Me.SpellReady[Focused Hail of Arrows]}) /varset c_Ready FALSE
+		/if (!${Me.SpellReady[Hail of Arrows]}) /varset c_Ready FALSE
+
+	} else /if (${Me.SpellReady[${${ArrayName}[${ArrayIndex},${iCastName}]}]}) /varset c_Ready TRUE
  
   } else /if (${${ArrayName}[${ArrayIndex},${iCastType}].Equal[Item]}) {
 	|Need to check if we already have this item on cooldown

--- a/Macros/e3 Includes/e3_Classes_Bard.inc
+++ b/Macros/e3 Includes/e3_Classes_Bard.inc
@@ -527,7 +527,7 @@ SUB unpauseTwist
       /return
    }
   
-	/delay 3s !${Me.Casting.ID}
+	/delay 3s !${Window[CastingWindow].Open}
 	
   /if (!${Bool[${playingMelody}]}) {
      /declare songList string local
@@ -548,7 +548,7 @@ SUB unpauseTwist
        
         /twist ${songSet}
       } 
-      /delay 1s ${Me.Casting.ID}
+      /delay 1s ${Window[CastingWindow].Open}
     
     } else {
 

--- a/Macros/e3 Includes/e3_ClearXTargets.inc
+++ b/Macros/e3 Includes/e3_ClearXTargets.inc
@@ -3,6 +3,7 @@
 |
 | Author: Sirhopsalot
 | Contributor: Forsy
+| Updated: Rekka
 |
 | Starts assist on each of the targets in your XTarget list until they're all Cleared using the criteria below
 | This will cause the toon to stick to the current target, face the mob if looking the wrong way, and re-stick if the mob is too far away
@@ -115,48 +116,55 @@ SUB event_nextTarget(line, ChatSender)
   /declare mobClass string local Warrior
   /declare mobHealth int local
   
-  
-
-
   /declare XtargetClosestDistance int local 99999
+  /declare XtargetClosestDistanceAggro int local 99999
+  /declare foundAgroMob bool local false
 
   /for i 1 to 13
-
-    /if (${Me.XTarget[${i}].LineOfSight} && ${Me.XTarget[${i}].Distance} > 75) {
-      /continue
-    }
-    /if (${Bool[${Me.XTarget[${i}].Name.Find[Corpse]}]} || ${Bool[${Me.XTarget[${i}].Name.Find[wooden box]}]}) {
-      /continue
-    }
-    /if (${Bool[${Me.XTarget[${i}].Name.Find[Chest]}]} || ${Bool[${Me.XTarget[${i}].Name.Find[a barrel]}]}  ) {
-       /continue
-    }
-    /if (${Bool[${Me.XTarget[${i}].Name.Find[a box]}]} || ${Bool[${Me.XTarget[${i}].Name.Find[crate]}]} || ${Bool[${Me.XTarget[${i}].Name.Find[hollow_tree]}]}) {
-       /continue
-    }
-   
-
+  
     /if (${Me.XTarget[${i}].TargetType.Equal[Auto Hater]}  ) {
-      |go for the closest of the valid targets first
-
-      /if (${KeepAggroOn} &&  (${Me.XTarget[${i}].PctAggro} < ${worstAggro} || (${Me.XTarget[${i}].PctAggro} == ${worstAggro} && ${mobClass.Equal[Warrior]} && ${Me.XTarget[${i}].PctHPs} >= ${mobHealth}))) {
-          /echo Finding target based off agro
-          /varset worstAggro ${Me.XTarget[${i}].PctAggro}
-          /varset mobId ${Me.XTarget[${i}].ID}
-          /varset mobClass ${Me.XTarget[${i}].Class}
-          /varset mobHealth ${Me.XTarget[${i}].PctHPs}
-
-      } else /if (${XtargetClosestDistance}> ${Me.XTarget[${i}].Distance} && ${Bool[${Spawn[${Me.XTarget[${i}].ID}]}]}  ) {
-          /echo Finding target based off distance
-          /varset worstAggro ${Me.XTarget[${i}].PctAggro}
-          /varset mobId ${Me.XTarget[${i}].ID}
-          /varset mobClass ${Me.XTarget[${i}].Class}
-          /varset mobHealth ${Me.XTarget[${i}].PctHPs}
-          /varset XtargetClosestDistance  ${Me.XTarget[${i}].Distance} 
+ 
+      |if not a valid spawn, skip
+      /if (${Me.XTarget[${i}].ID}<1 || !${Bool[${Spawn[${Me.XTarget[${i}].ID}]}]} ) { 
+        /continue
       }
+      /if (!${Me.XTarget[${i}].LineOfSight} || ${Me.XTarget[${i}].Distance} > 30) {
+        /continue
+      }
+      /if (${Bool[${Me.XTarget[${i}].Name.Find[Corpse]}]} || ${Bool[${Me.XTarget[${i}].Name.Find[wooden box]}]}) {
+        /continue
+      }
+      /if (${Bool[${Me.XTarget[${i}].Name.Find[Chest]}]} || ${Bool[${Me.XTarget[${i}].Name.Find[a barrel]}]}  ) {
+        /continue
+      }
+      /if (${Bool[${Me.XTarget[${i}].Name.Find[a box]}]} || ${Bool[${Me.XTarget[${i}].Name.Find[crate]}]} || ${Bool[${Me.XTarget[${i}].Name.Find[hollow_tree]}]}) {
+        /continue
+      }
+    
+        |go for the closest of the valid targets first
+
+        /if (${KeepAggroOn} &&  ${XtargetClosestDistanceAggro}> ${Me.XTarget[${i}].Distance} && (${Me.XTarget[${i}].PctAggro} < ${worstAggro} || (${Me.XTarget[${i}].PctAggro} == ${worstAggro} && ${mobClass.Equal[Warrior]} && ${Me.XTarget[${i}].PctHPs} >= ${mobHealth}))) {
+            /echo Finding target based off agro: ${Me.XTarget[${i}].ID}
+            /varset worstAggro ${Me.XTarget[${i}].PctAggro}
+            /varset mobId ${Me.XTarget[${i}].ID}
+            /varset mobClass ${Me.XTarget[${i}].Class}
+            /varset mobHealth ${Me.XTarget[${i}].PctHPs}
+            /varset foundAgroMob true
+            /varset XtargetClosestDistanceAggro  ${Me.XTarget[${i}].Distance} 
+
+        }
+        |if we didn't find a mob via agro, try and select one via distance 
+        /if (!${foundAgroMob} && ${XtargetClosestDistance}> ${Me.XTarget[${i}].Distance} && ${Bool[${Spawn[${Me.XTarget[${i}].ID}]}]}  ) {
+            /echo Finding target based off distance: ${Me.XTarget[${i}].ID}
+            /varset worstAggro ${Me.XTarget[${i}].PctAggro}
+            /varset mobId ${Me.XTarget[${i}].ID}
+            /varset mobClass ${Me.XTarget[${i}].Class}
+            /varset mobHealth ${Me.XTarget[${i}].PctHPs}
+            /varset XtargetClosestDistance  ${Me.XTarget[${i}].Distance} 
+        }
     }
   /next i
-  /echo mob selected : ${mobId} is it a valid spawn?:${Bool[${Spawn[${mobId}]}]} 
+  /echo mob selected : ${mobId}
   /varset ClearXTargetsDebug true
   /if (${Bool[${mobId}]} && ${Bool[${Spawn[${mobId}]}]}) {
     /if (${ClearXTargetsDebug}) /echo Assisting on Next Target ${Spawn[${mobId}].CleanName} TargetID=${mobId}
@@ -169,9 +177,7 @@ SUB event_nextTarget(line, ChatSender)
  
     |/stick id ${mobId} ${ClearXTargetStickDistance} uw
    
-    /delay 5
     /attack on
-    /delay 5
     |/bcga //pet attack
     |/delay 1
     /assistme

--- a/Macros/e3 Includes/e3_ClearXTargets.inc
+++ b/Macros/e3 Includes/e3_ClearXTargets.inc
@@ -3,7 +3,7 @@
 |
 | Author: Sirhopsalot
 | Contributor: Forsy
-| Updated: Rekka
+| Updated/Enchanced: Rekka
 |
 | Starts assist on each of the targets in your XTarget list until they're all Cleared using the criteria below
 | This will cause the toon to stick to the current target, face the mob if looking the wrong way, and re-stick if the mob is too far away
@@ -12,9 +12,13 @@
 | WARNING: This macro is not for AFK grinding. AFK grinding using this or any other macro is against the rules for Lazarus. Please don't do it.
 |
 | Selects the next target from the XTarget list using the following criteria:
-| 1) Lowest aggro on the list
-| 2) Highest health on the list
-| 2a) Prefers non-Warrior targets with the same aggro over Warrior targets (kill healers/casters/rogues/etc first)
+| 
+| Update was done on the below rules to always chose the closest of all targets first while keeping with rules.
+| Note rules are only followed if KeepAggro is used. Otherwise its purely closest mob at 75% melee max range.
+|
+| **1) Lowest aggro on the list
+| **2) Highest health on the list
+| **2a) Prefers non-Warrior targets with the same aggro over Warrior targets (kill healers/casters/rogues/etc first)
 
 | Usage to clear everything:
 |    /bc Clear XTargets

--- a/Macros/e3 Includes/e3_ClearXTargets.inc
+++ b/Macros/e3 Includes/e3_ClearXTargets.inc
@@ -114,28 +114,69 @@ SUB event_nextTarget(line, ChatSender)
   /declare mobId int local
   /declare mobClass string local Warrior
   /declare mobHealth int local
+  
+  
+
+
+  /declare XtargetClosestDistance int local 99999
+
   /for i 1 to 13
-    /if (${Me.XTarget[${i}].TargetType.Equal[Auto Hater]} && (${Me.XTarget[${i}].PctAggro} < ${worstAggro} || (${Me.XTarget[${i}].PctAggro} == ${worstAggro} && ${mobClass.Equal[Warrior]} && ${Me.XTarget[${i}].PctHPs} >= ${mobHealth})) && !${Bool[${Me.XTarget[${i}].Name.Find[Corpse]}]} && !${Bool[${Me.XTarget[${i}].Name.Find[wooden box]}]} && !${Bool[${Me.XTarget[${i}].Name.Find[Chest]}]} && !${Bool[${Me.XTarget[${i}].Name.Find[a barrel]}]} && !${Bool[${Me.XTarget[${i}].Name.Find[a box]}]} && !${Bool[${Me.XTarget[${i}].Name.Find[crate]}]} && !${Bool[${Me.XTarget[${i}].Name.Find[hollow_tree]}]} && ${Me.XTarget[${i}].LineOfSight} && ${Me.XTarget[${i}].Distance} < 75) {
-      /varset worstAggro ${Me.XTarget[${i}].PctAggro}
-      /varset mobId ${Me.XTarget[${i}].ID}
-      /varset mobClass ${Me.XTarget[${i}].Class}
-      /varset mobHealth ${Me.XTarget[${i}].PctHPs}
+
+    /if (${Me.XTarget[${i}].LineOfSight} && ${Me.XTarget[${i}].Distance} > 75) {
+      /continue
+    }
+    /if (${Bool[${Me.XTarget[${i}].Name.Find[Corpse]}]} || ${Bool[${Me.XTarget[${i}].Name.Find[wooden box]}]}) {
+      /continue
+    }
+    /if (${Bool[${Me.XTarget[${i}].Name.Find[Chest]}]} || ${Bool[${Me.XTarget[${i}].Name.Find[a barrel]}]}  ) {
+       /continue
+    }
+    /if (${Bool[${Me.XTarget[${i}].Name.Find[a box]}]} || ${Bool[${Me.XTarget[${i}].Name.Find[crate]}]} || ${Bool[${Me.XTarget[${i}].Name.Find[hollow_tree]}]}) {
+       /continue
+    }
+   
+
+    /if (${Me.XTarget[${i}].TargetType.Equal[Auto Hater]}  ) {
+      |go for the closest of the valid targets first
+
+      /if (${KeepAggroOn} &&  (${Me.XTarget[${i}].PctAggro} < ${worstAggro} || (${Me.XTarget[${i}].PctAggro} == ${worstAggro} && ${mobClass.Equal[Warrior]} && ${Me.XTarget[${i}].PctHPs} >= ${mobHealth}))) {
+          /echo Finding target based off agro
+          /varset worstAggro ${Me.XTarget[${i}].PctAggro}
+          /varset mobId ${Me.XTarget[${i}].ID}
+          /varset mobClass ${Me.XTarget[${i}].Class}
+          /varset mobHealth ${Me.XTarget[${i}].PctHPs}
+
+      } else /if (${XtargetClosestDistance}> ${Me.XTarget[${i}].Distance} && ${Bool[${Spawn[${Me.XTarget[${i}].ID}]}]}  ) {
+          /echo Finding target based off distance
+          /varset worstAggro ${Me.XTarget[${i}].PctAggro}
+          /varset mobId ${Me.XTarget[${i}].ID}
+          /varset mobClass ${Me.XTarget[${i}].Class}
+          /varset mobHealth ${Me.XTarget[${i}].PctHPs}
+          /varset XtargetClosestDistance  ${Me.XTarget[${i}].Distance} 
+      }
     }
   /next i
-
+  /echo mob selected : ${mobId} is it a valid spawn?:${Bool[${Spawn[${mobId}]}]} 
+  /varset ClearXTargetsDebug true
   /if (${Bool[${mobId}]} && ${Bool[${Spawn[${mobId}]}]}) {
     /if (${ClearXTargetsDebug}) /echo Assisting on Next Target ${Spawn[${mobId}].CleanName} TargetID=${mobId}
     /call TrueTarget ${mobId}
+    /if (${Target.Distance}>${Math.Calc[${Spawn[${Target.ID}].MaxRangeTo}*.75].Int}) {
+       /stick
+    } else {
+      /face fast id ${mobId}
+    }
+ 
     |/stick id ${mobId} ${ClearXTargetStickDistance} uw
-    /face fast id ${mobId}
-    /delay 1
+   
+    /delay 5
     /attack on
-    /delay 1
-    /bcga //pet attack
-    /delay 1
+    /delay 5
+    |/bcga //pet attack
+    |/delay 1
     /assistme
     /varset AllowControl TRUE
-    /varset AssistStickDistance ${ClearXTargetStickDistance}
+    /varset AssistStickDistance ${Target.Distance}>${Math.Calc[${Spawn[${Target.ID}].MaxRangeTo}*.75].Int}
   } else {
     /if (${ClearXTargetsDebug}) /echo No mobs on XTarget to assist on
   }
@@ -159,7 +200,8 @@ SUB event_getCloserClearXTargets
 	/if (${Bool[${AssistTarget}]}) {
 		/doevent flush event_getCloserClearXTargets
 		/if (${ClearXTargetsDebug}) /echo ClearXTargets: Re-sticking to target ${Spawn[id ${AssistTarget}].CleanName}
-		/stick id ${AssistTarget} 5 uw
+    /call TrueTarget ${AssistTarget}
+		/stick
 	}
 /RETURN
 
@@ -248,7 +290,13 @@ SUB event_rotateTarget(line, ChatSender)
   /if (${Bool[${mobId}]} && ${Bool[${Spawn[${mobId}]}]}) {
     /if (${ClearXTargetsDebug}) /echo Assisting on Next Rotate Target ${Spawn[${mobId}].CleanName} TargetID=${mobId}
     /call TrueTarget ${mobId}
-    /stick id ${mobId} ${ClearXTargetStickDistance} uw
+
+    /if (${Target.Distance}>${Math.Calc[${Spawn[${Target.ID}].MaxRangeTo}*.75].Int}) {
+      /stick
+    } else {
+      /face fast id ${mobId}
+    }
+ 
     /delay 1
     /attack on
     /delay 1
@@ -256,7 +304,7 @@ SUB event_rotateTarget(line, ChatSender)
     /delay 1
     /assistme
     /varset AllowControl TRUE
-    /varset AssistStickDistance ${ClearXTargetStickDistance}
+    /varset AssistStickDistance ${Target.Distance}>${Math.Calc[${Spawn[${Target.ID}].MaxRangeTo}*.75].Int}
   } else {
     /if (${ClearXTargetsDebug}) /echo No mobs on XTarget to assist on
   }

--- a/Macros/e3 Includes/e3_Heals.inc
+++ b/Macros/e3 Includes/e3_Heals.inc
@@ -142,7 +142,7 @@ SUB heal_importantBots
   /declare GroupMemberIndex int local -1	
   /for t 1 to ${importantBots.Size}
     /for s 1 to ${importantHeals2D.Size[1]}
-
+	/varset GroupMemberIndex -1
 
 	|Netbots seems to sometimes.. lag? freeze? etc. Have a local group heal check as backup
 	|if we can't find a local group heal to heal, then check netbots. at worst case we overheal.

--- a/Macros/e3 Includes/e3_Heals.inc
+++ b/Macros/e3 Includes/e3_Heals.inc
@@ -11,17 +11,30 @@
 |------------------------------------------------------------|
 SUB check_Heals
 /if (${Debug} || ${Debug_Heals}) /echo |- healLoop  ==>
-  /doevents wordHeal
-	/if (${do_GroupHeals}) 							      /call groupHeals
-	/if (!${ActionTaken} && ${healTanks}) 		/call heal_tanks
-	/if (!${ActionTaken} && ${healImportant}) /call heal_importantBots
-	/if (!${ActionTaken} && ${healAll}) 			/call heal_allbots
-	/if (!${ActionTaken} && ${healXTargets}) 			/call heal_xtargets
-	/if (!${ActionTaken} && ${hotTanks}) 			/call hot_tanks
-	/if (!${ActionTaken} && ${hotImportant}) 	/call hot_importantBots
-	/if (!${ActionTaken} && ${hotAll}) 				/call hot_allbots
-	/if (!${ActionTaken} && ${healPets}) 			/call heal_Pets
-	/if (!${ActionTaken} && ${hotPets}) 			/call hot_Pets
+  	/doevents wordHeal
+
+	/varset ActionTaken True
+	/declare AtLeastOneActionTaken bool local False
+	/while (${ActionTaken}) {
+		/varset ActionTaken False
+		/if (${healTanks}) 		/call heal_tanks
+		/if (${healXTargets}) 	/call heal_xtargets
+		/if (!${ActionTaken} && ${healImportant})   /call heal_importantBots
+		/if (!${ActionTaken} && ${do_GroupHeals}) 	/call groupHeals
+		/if (!${ActionTaken} && ${healAll}) 			/call heal_allbots
+		/if (!${ActionTaken} && ${hotTanks}) 			/call hot_tanks
+		/if (!${ActionTaken} && ${hotImportant}) 	/call hot_importantBots
+		/if (!${ActionTaken} && ${hotAll}) 				/call hot_allbots
+		/if (!${ActionTaken} && ${healPets}) 			/call heal_Pets
+		/if (!${ActionTaken} && ${hotPets}) 			/call hot_Pets
+		
+		/if (${ActionTaken}) {
+			/varset AtLeastOneActionTaken true
+		}
+	}
+	|set actiontaken back to what it should be, if any action was taken.
+	/varset ActionTaken ${AtLeastOneActionTaken}
+	
 /if (${Debug} || ${Debug_Heals}) /echo <== healLoop -|
 /return
 
@@ -61,15 +74,39 @@ SUB heal_tanks
 	/declare currentBot string local NULL
 	/declare currentSpellIndx int local
 	/declare t int local
-	/declare s int local	
+	/declare s int local
+	/declare GroupMemberIndex int local -1	
 	/for t 1 to ${tanks.Size}
 		/for s 1 to ${tankHeals2D.Size[1]}
-			/if (${Bool[${NetBots[${tanks[${t}]}].InZone}]} && ${NetBots[${tanks[${t}]}].PctHPs} <= ${tankHeals2D[${s},${iHealPct}]}) {
+		/varset GroupMemberIndex -1
+
+			|Netbots seems to sometimes.. lag? freeze? etc. Have a local group heal check as backup
+			|if we can't find a local group heal to heal, then check netbots. at worst case we overheal.
+			/if (${Bool[${Group.Member[${tanks[${t}]}].Index}]}) {
+				/varset GroupMemberIndex ${Group.Member[${tanks[${t}]}].Index}
+			|	/echo Group member index for tank : ${GroupMemberIndex}
+			}
+			|try a group based check
+			/if (${GroupMemberIndex} >-1 && !${Group.Member[${GroupMemberIndex}].OtherZone} && ${Group.Member[${GroupMemberIndex}].Spawn.CurrentHPs} < ${tankHeals2D[${s},${iHealPct}]}) {
+				/call check_Ready "tankHeals2D" ${s}		
+				/if (${c_Ready} && ${tankHeals2D[${s},${iIfs}]}) {
+					/if (${check_Distance[${NetBots[${tanks[${t}]}].ID},${tankHeals2D[${s},${iMyRange}]}]}) {
+						/if (${check_Mana["tankHeals2D",${s}]}) {
+									/echo [${Time}] heal_tanks: selecting :  ${tanks[${t}]} To heal from group heal code. ${Group.Member[${GroupMemberIndex}].Spawn.CurrentHPs} vs ${NetBots[${tanks[${t}]}].PctHPs}
+									/varset currentBot ${tanks[${t}]}
+									/varset currentSpellIndx ${s}
+						}
+					}
+				}
+			}
+			|did we find current bot to heal? if not fall back to netbots to check
+			/if (!${Bool[${currentBot}]} && ${Bool[${NetBots[${tanks[${t}]}].InZone}]} && ${NetBots[${tanks[${t}]}].PctHPs} <= ${tankHeals2D[${s},${iHealPct}]}) {
 
 				/call check_Ready "tankHeals2D" ${s}		
 				/if (${c_Ready} && ${tankHeals2D[${s},${iIfs}]}) {
 					/if (${check_Distance[${NetBots[${tanks[${t}]}].ID},${tankHeals2D[${s},${iMyRange}]}]}) {
 						/if (${check_Mana["tankHeals2D",${s}]}) {
+									/echo [${Time}] heal_tanks: selecting :  ${tanks[${t}]} To heal from netbots heal code.  ${Group.Member[${GroupMemberIndex}].Spawn.CurrentHPs} vs ${NetBots[${tanks[${t}]}].PctHPs}
 									/varset currentBot ${tanks[${t}]}
 									/varset currentSpellIndx ${s}
 						}
@@ -102,8 +139,29 @@ SUB heal_importantBots
   /declare currentSpellIndx int local
   /declare t int local
   /declare s int local
+  /declare GroupMemberIndex int local -1	
   /for t 1 to ${importantBots.Size}
     /for s 1 to ${importantHeals2D.Size[1]}
+
+
+	|Netbots seems to sometimes.. lag? freeze? etc. Have a local group heal check as backup
+	|if we can't find a local group heal to heal, then check netbots. at worst case we overheal.
+	/if (${Bool[${Group.Member[${importantBots[${t}]}].Index}]}) {
+		/varset GroupMemberIndex ${Group.Member[${importantBots[${t}]}].Index}
+	|	/echo Group member index for tank : ${GroupMemberIndex}
+	}
+	|try a group based check
+	/if (${GroupMemberIndex} >-1 && !${Group.Member[${GroupMemberIndex}].OtherZone} && ${Group.Member[${GroupMemberIndex}].Spawn.CurrentHPs} < ${importantHeals2D[${s},${iHealPct}]}) {
+		/call check_Ready "importantHeals2D" ${s}		
+		/if (${c_Ready} && ${importantHeals2D[${s},${iIfs}]}) {
+			/if (${check_Distance[${NetBots[${importantBots[${t}]}].ID},${importantHeals2D[${s},${iMyRange}]}]}) {
+				/if (${check_Mana["importantHeals2D",${s}]}) {
+							/varset currentBot ${importantBots[${t}]}
+							/varset currentSpellIndx ${s}
+				}
+			}
+		}
+	}
     /if (${Bool[${NetBots[${importantBots[${t}]}].InZone}]} && ${NetBots[${importantBots[${t}]}].PctHPs} <= ${importantHeals2D[${s},${iHealPct}]}) {
      /call check_Ready "importantHeals2D" ${s}
       /if (${c_Ready} && ${importantHeals2D[${s},${iIfs}]}) {

--- a/Macros/e3 Includes/e3_Loot.inc
+++ b/Macros/e3 Includes/e3_Loot.inc
@@ -163,7 +163,10 @@ SUB lootCorpse
   /varset canLootCorpse TRUE
   /declare importantItem bool local
   /varcalc freeInventory ${freeInventory}-${LootNumOfFreeSlotsOpen}
-  
+  /if (${freeInventory}<1) {
+    /varset ${freeInventory} 0
+  }
+
   /loot
   /delay 5 ${Window[LootWnd].Open}
   /doevents NotYourKill

--- a/Macros/e3 Includes/e3_Loot.inc
+++ b/Macros/e3 Includes/e3_Loot.inc
@@ -157,11 +157,13 @@ SUB lootCorpse
   /declare i int local
   /declare j int local
   /declare stackCounter int local 
-
+  /declare freeInventory int Local ${Me.FreeInventory}
   /declare itemName string local
   /declare itemSlot int local
   /varset canLootCorpse TRUE
   /declare importantItem bool local
+  /varcalc freeInventory ${freeInventory}-${LootNumOfFreeSlotsOpen}
+  
   /loot
   /delay 5 ${Window[LootWnd].Open}
   /doevents NotYourKill
@@ -184,7 +186,7 @@ SUB lootCorpse
   |must use numItems, ${Corpse.Items} recalcs every iteration
   /for i 1 to ${numItems}
     |/if (${Debug} || ${Debug_Loot}) /echo starting loot i: ${i} of ${numItems}
-    /if (!${Me.FreeInventory}) {
+    /if (!${freeInventory}) {
       /if (!${fullInventory_Alert}) {
         /beep
         /varset fullInventory_Alert TRUE
@@ -336,8 +338,16 @@ SUB lootCorpse
       | 2) The item on the corpse is stackable
       | 3) I have one of the stackable items in my inventory already
       | Then check to see if there is room within the stack to loot it.
-      /if (${Me.FreeInventory}) {
-      } else /if (!${Me.LargestFreeInventory} && ${Corpse.Item[${i}].Stackable} && ${Bool[${FindItem[=${itemName}]}]}) {
+      /if (${freeInventory}) {
+
+        |we have some free inventory slots, lets see if any of them can contain the item we wish
+        /if (${Me.LargestFreeInventory} < ${Corpse.Item[${i}].Size}) { 
+            /echo [${Time}]: Loot: I don't have a free inventory space large enough to hold [${itemName}].
+            /goto :skipItem
+        }
+
+      } else /if (!${freeInventory} && ${Corpse.Item[${i}].Stackable} && ${Bool[${FindItem[=${itemName}]}]}) {
+
         /if (${Debug} || ${Debug_Loot}) /bc [Auto-Loot]: Check stackables
 
         /if (!${Bool[${FindItem[=${itemName}].ItemSlot}]}) /goto :skipItem
@@ -358,10 +368,7 @@ SUB lootCorpse
         } else {
           /goto :skipItem
         }
-      } else /if (${Me.LargestFreeInventory} < ${Corpse.Item[${i}].Size}) {
-        /echo [${Time}]: Loot: I don't have a free inventory space large enough to hold [${itemName}].
-        /goto :skipItem
-      }  else /if (!${Me.FreeInventory}) {
+      } else /if (!${freeInventory}) {
         /if (${Debug} || ${Debug_Loot}) /bc [+g+] [Auto-Loot]: No Free Space
         /goto :skipItem
       }
@@ -581,6 +588,7 @@ SUB loot_Setup
   /declare canLootCorpse bool outer FALSE
   /declare cantLootCorpseCount int outer FALSE
   /declare lootSetting string outer
+  /declare LootNumOfFreeSlotsOpen int outer 0
 
 	/if (!${Ini[${Loot_Ini}].Length}) /call Build_Alphabetized_Ini "${Loot_Ini}"
 	/call iniToVarV "${genSettings_Ini},Loot,Loot Link Channel" linkChannel string outer
@@ -590,6 +598,7 @@ SUB loot_Setup
 
 	| Import character settings
 	/if (${Bool[${Ini[${Character_Ini},Misc,Auto-Loot (On/Off)]}]}) /call iniToVarV "${Character_Ini},Misc,Auto-Loot (On/Off)" Auto_Loot bool outer
+  /if (${Ini[${genSettings_Ini},Loot,LootNumOfFreeSlotsOpen(1+)].Length}) /call iniToVarV "${genSettings_Ini},Loot,LootNumOfFreeSlotsOpen(1+)" LootNumOfFreeSlotsOpen int outer
   /if (${Ini[${genSettings_Ini},Loot,Loot Only Stackable: Enable (On/Off)].Length}) /call iniToVarV "${genSettings_Ini},Loot,Loot Only Stackable: Enable (On/Off)" LootOnlyStackableEnabled bool outer
   /if (${Ini[${genSettings_Ini},Loot,Loot Only Stackable: With Value Greater Than Or Equal in Copper].Length}) /call iniToVarV "${genSettings_Ini},Loot,Loot Only Stackable: With Value Greater Than Or Equal in Copper" LootOnlyStackableValueGreater int outer
   /if (${Ini[${genSettings_Ini},Loot,Loot Only Stackable: Loot common tradeskill items ie:pelts ores silks etc (On/Off)].Length}) /call iniToVarV "${genSettings_Ini},Loot,Loot Only Stackable: Loot common tradeskill items ie:pelts ores silks etc (On/Off)" LootOnlyStackableTradeSkillsCommon bool outer

--- a/Macros/e3 Includes/e3_Loot.inc
+++ b/Macros/e3 Includes/e3_Loot.inc
@@ -162,10 +162,7 @@ SUB lootCorpse
   /declare itemSlot int local
   /varset canLootCorpse TRUE
   /declare importantItem bool local
-  /varcalc freeInventory ${freeInventory}-${LootNumOfFreeSlotsOpen}
-  /if (${freeInventory}<1) {
-    /varset freeInventory 0
-  }
+ 
 
   /loot
   /delay 5 ${Window[LootWnd].Open}
@@ -188,8 +185,13 @@ SUB lootCorpse
 
   |must use numItems, ${Corpse.Items} recalcs every iteration
   /for i 1 to ${numItems}
+    |recalculate the free inventory
+    /varcalc freeInventory ${Me.FreeInventory}-${LootNumOfFreeSlotsOpen}
+    /if (${freeInventory}<1) {
+      /varset freeInventory 0
+    }
     |/if (${Debug} || ${Debug_Loot}) /echo starting loot i: ${i} of ${numItems}
-    /if (!${freeInventory}) {
+    /if (${freeInventory}<1) {
       /if (!${fullInventory_Alert}) {
         /beep
         /varset fullInventory_Alert TRUE
@@ -341,7 +343,7 @@ SUB lootCorpse
       | 2) The item on the corpse is stackable
       | 3) I have one of the stackable items in my inventory already
       | Then check to see if there is room within the stack to loot it.
-      /if (${freeInventory}) {
+      /if (${freeInventory}>1) {
 
         |we have some free inventory slots, lets see if any of them can contain the item we wish
         /if (${Me.LargestFreeInventory} < ${Corpse.Item[${i}].Size}) { 
@@ -349,7 +351,7 @@ SUB lootCorpse
             /goto :skipItem
         }
 
-      } else /if (!${freeInventory} && ${Corpse.Item[${i}].Stackable} && ${Bool[${FindItem[=${itemName}]}]}) {
+      } else /if (${freeInventory}<1 && ${Corpse.Item[${i}].Stackable} && ${Bool[${FindItem[=${itemName}]}]}) {
 
         /if (${Debug} || ${Debug_Loot}) /bc [Auto-Loot]: Check stackables
 
@@ -371,7 +373,7 @@ SUB lootCorpse
         } else {
           /goto :skipItem
         }
-      } else /if (!${freeInventory}) {
+      } else /if (${freeInventory}<1) {
         /if (${Debug} || ${Debug_Loot}) /bc [+g+] [Auto-Loot]: No Free Space
         /goto :skipItem
       }

--- a/Macros/e3 Includes/e3_Loot.inc
+++ b/Macros/e3 Includes/e3_Loot.inc
@@ -604,7 +604,6 @@ SUB loot_Setup
   /if (${Ini[${genSettings_Ini},Loot,Loot Only Stackable: Loot common tradeskill items ie:pelts ores silks etc (On/Off)].Length}) /call iniToVarV "${genSettings_Ini},Loot,Loot Only Stackable: Loot common tradeskill items ie:pelts ores silks etc (On/Off)" LootOnlyStackableTradeSkillsCommon bool outer
   /if (${Ini[${genSettings_Ini},Loot,Loot Only Stackable: Loot all Tradeskill items (On/Off)].Length})  /call iniToVarV "${genSettings_Ini},Loot,Loot Only Stackable: Loot all Tradeskill items (On/Off)" LootOnlyStackableTradeSkillsALL bool outer
   /call IniToArrayV "${genSettings_Ini},Loot,Loot Only Stackable: Always Loot Item#"	stackableItemArray
-  /echo Loot Free SLots: ${LootNumOfFreeSlotsOpen}
   |**/if (${Defined[stackableItemArray]}) {
      /declare i int local 
     /for i 1 to ${stackableItemArray.Size}

--- a/Macros/e3 Includes/e3_Loot.inc
+++ b/Macros/e3 Includes/e3_Loot.inc
@@ -395,7 +395,7 @@ SUB lootCorpse
   |/delay 1
   |looting done, if items leftover link them
   |if numitems was 0, no reason to query the corpse again.
-  /if (${numItems}>0) {
+  /if (${linkChannel.Length}>0 && ${numItems}>0) {
     /if (${Corpse.Items}) {
       /keypress /
       /delay 1

--- a/Macros/e3 Includes/e3_Loot.inc
+++ b/Macros/e3 Includes/e3_Loot.inc
@@ -100,7 +100,7 @@ SUB loot_Area
     /varset CorpseList ${CorpseList}${ClosestCorpse}|
   /next i
   /if (${Debug} || ${Debug_Loot}) /echo CorpseList: ${CorpseList}
-  /if (${NumCorpses}>1) {
+  /if (${NumCorpses}>0) {
     /squelch /hidecor looted
   }
   /for i 1 to ${NumCorpses}

--- a/Macros/e3 Includes/e3_Loot.inc
+++ b/Macros/e3 Includes/e3_Loot.inc
@@ -164,7 +164,7 @@ SUB lootCorpse
   /declare importantItem bool local
   /varcalc freeInventory ${freeInventory}-${LootNumOfFreeSlotsOpen}
   /if (${freeInventory}<1) {
-    /varset ${freeInventory} 0
+    /varset freeInventory 0
   }
 
   /loot

--- a/Macros/e3 Includes/e3_Loot.inc
+++ b/Macros/e3 Includes/e3_Loot.inc
@@ -497,7 +497,7 @@ SUB loot_Handle(int slotNum, handle)
 	/declare lootTimer timer local 3s
 	:retry_Loot
 	| Try to loot the specified item from the corpse.
-	/itemnotify loot${slotNum} rightmouseup
+	/itemnotify loot${slotNum} leftmouseup
 
 	/delay 1s ${Cursor.ID} || ${Window[ConfirmationDialogBox].Open} || ${Window[QuantityWnd].Open}
 	| If the item has been looted, decide what to do with it.

--- a/Macros/e3 Includes/e3_Loot.inc
+++ b/Macros/e3 Includes/e3_Loot.inc
@@ -598,13 +598,13 @@ SUB loot_Setup
 
 	| Import character settings
 	/if (${Bool[${Ini[${Character_Ini},Misc,Auto-Loot (On/Off)]}]}) /call iniToVarV "${Character_Ini},Misc,Auto-Loot (On/Off)" Auto_Loot bool outer
-  /if (${Ini[${genSettings_Ini},Loot,LootNumOfFreeSlotsOpen(1+)].Length}) /call iniToVarV "${genSettings_Ini},Loot,LootNumOfFreeSlotsOpen(1+)" LootNumOfFreeSlotsOpen int outer
+  /if (${Ini[${genSettings_Ini},Loot,NumOfFreeSlotsOpen(1+)].Length}) /call iniToVarV "${genSettings_Ini},Loot,NumOfFreeSlotsOpen(1+)" LootNumOfFreeSlotsOpen int outer
   /if (${Ini[${genSettings_Ini},Loot,Loot Only Stackable: Enable (On/Off)].Length}) /call iniToVarV "${genSettings_Ini},Loot,Loot Only Stackable: Enable (On/Off)" LootOnlyStackableEnabled bool outer
   /if (${Ini[${genSettings_Ini},Loot,Loot Only Stackable: With Value Greater Than Or Equal in Copper].Length}) /call iniToVarV "${genSettings_Ini},Loot,Loot Only Stackable: With Value Greater Than Or Equal in Copper" LootOnlyStackableValueGreater int outer
   /if (${Ini[${genSettings_Ini},Loot,Loot Only Stackable: Loot common tradeskill items ie:pelts ores silks etc (On/Off)].Length}) /call iniToVarV "${genSettings_Ini},Loot,Loot Only Stackable: Loot common tradeskill items ie:pelts ores silks etc (On/Off)" LootOnlyStackableTradeSkillsCommon bool outer
   /if (${Ini[${genSettings_Ini},Loot,Loot Only Stackable: Loot all Tradeskill items (On/Off)].Length})  /call iniToVarV "${genSettings_Ini},Loot,Loot Only Stackable: Loot all Tradeskill items (On/Off)" LootOnlyStackableTradeSkillsALL bool outer
   /call IniToArrayV "${genSettings_Ini},Loot,Loot Only Stackable: Always Loot Item#"	stackableItemArray
-  
+  /echo Loot Free SLots: ${LootNumOfFreeSlotsOpen}
   |**/if (${Defined[stackableItemArray]}) {
      /declare i int local 
     /for i 1 to ${stackableItemArray.Size}
@@ -623,6 +623,8 @@ SUB loot_MacroSettings
 	/call WriteToIni "${genSettings_Ini},Loot,Loot Link Channel" say
 	/call WriteToIni "${genSettings_Ini},Loot,Corpse Seek Radius" 125
   /call WriteToIni "${genSettings_Ini},Loot,Loot in Combat" TRUE
+  /call WriteToIni "${genSettings_Ini},Loot,NumOfFreeSlotsOpen(1+)" 0
+  
 /if (${Debug}) /echo <== _MacroSettings -|
 /RETURN
 

--- a/Macros/e3 Includes/e3_Loot.inc
+++ b/Macros/e3 Includes/e3_Loot.inc
@@ -147,7 +147,7 @@ SUB loot_Area
   } else {
     /call MoveToLoc ${startY} ${startX} 15 20
   }
-  /squelch /hidecor npc 
+  |/squelch /hidecor npc 
   /docommand ${ChatToggle} ${Group.Leader} Looting Complete
   /if (${Debug} || ${Debug_Loot}) /echo <== loot_Area -|
 /return
@@ -383,7 +383,13 @@ SUB lootCorpse
       |delay 4 is needed per item so we don't accidently skip. Unsure how much delay will be impacted. 
       |if it is, uncomment out loot_handle and commonent out the itemnotify and /delay 4
       /itemnotify loot${i} rightmouseup
-      /delay 4
+      /delay 2
+      /while (${Bool[${Corpse.Item[${i}]}]}) {
+          |if item still on corpse, try again.
+          |/echo trying to loot again ${i}
+          /itemnotify loot${i} rightmouseup
+          /delay 1
+      }
       |/call loot_Handle ${i} keep
       |/if (${Debug} || ${Debug_Loot}) /echo Done Looting i: ${i}
      
@@ -467,9 +473,12 @@ SUB get_lootSetting(invSlot, itemSlot)
 		/varset iniEntryVariables ${If[${Me.Inventory[${invSlot}].Item[${itemSlot}].Stackable},(${Me.Inventory[${invSlot}].Item[${itemSlot}].StackSize}),]}${If[${Me.Inventory[${invSlot}].Item[${itemSlot}].NoDrop},(ND),]}${If[${Me.Inventory[${invSlot}].Item[${itemSlot}].Lore},(L),]}${If[${Me.Inventory[${invSlot}].Item[${itemSlot}].Container},(C),]}
 		| Check for a Loot_Ini entry
 		/if (!${Ini[${Loot_Ini},${itemName.Left[1]},${itemName} ${itemValue}${iniEntryVariables}].Length}) {
-			/call WriteToIni "${Loot_Ini},${itemName.Left[1]},${itemName} ${itemValue}${iniEntryVariables}" ${If[${Me.Inventory[${invSlot}].Item[${itemSlot}].Container},Container,${If[${Me.Inventory[${invSlot}].Item[${itemSlot}].NoDrop},Skip,Keep${If[${Me.Inventory[${invSlot}].Item[${itemSlot}].Stackable},|${Me.Inventory[${invSlot}].Item[${itemSlot}].StackSize},]}]}]}
-			/docommand ${ChatToggle} Added: [${Me.Inventory[${invSlot}].Item[${itemSlot}].Name}(${Ini[${Loot_Ini},${itemName.Left[1]},${itemName} ${itemValue}${iniEntryVariables}]})] to [${Loot_Ini}].
-			| Add scripts to import old loot settings from ninjaloot.ini, and old e3 loot inis
+			
+      /if (!(${LootOnlyStackableEnabled} &&  !${Me.Inventory[${invSlot}].Item[${itemSlot}].Stackable})) {
+        /call WriteToIni "${Loot_Ini},${itemName.Left[1]},${itemName} ${itemValue}${iniEntryVariables}" ${If[${Me.Inventory[${invSlot}].Item[${itemSlot}].Container},Container,${If[${Me.Inventory[${invSlot}].Item[${itemSlot}].NoDrop},Skip,Keep${If[${Me.Inventory[${invSlot}].Item[${itemSlot}].Stackable},|${Me.Inventory[${invSlot}].Item[${itemSlot}].StackSize},]}]}]}
+        /docommand ${ChatToggle} Added: [${Me.Inventory[${invSlot}].Item[${itemSlot}].Name}(${Ini[${Loot_Ini},${itemName.Left[1]},${itemName} ${itemValue}${iniEntryVariables}]})] to [${Loot_Ini}].
+      }
+ 			| Add scripts to import old loot settings from ninjaloot.ini, and old e3 loot inis
 		}
 	}
 	/varset lootSetting ${Ini[${Loot_Ini},${itemName.Left[1]},${itemName} ${itemValue}${iniEntryVariables}]}

--- a/Macros/e3 Includes/e3_Sell.inc
+++ b/Macros/e3 Includes/e3_Sell.inc
@@ -302,18 +302,16 @@ SUB sellItems
 								:retrySelect_Pack
 								/if (${Debug} || ${Debug_Sell}) /echo |- sellItems -| :retrySelect_Pack
 								/itemnotify in pack${i} ${e} leftmouseup
-								
-								/delay ${retryTimer} ${Window[MerchantWnd].Child[MW_SelectedItemLabel].Text.Equal[${Me.Inventory[pack${i}].Item[${e}]}]}
-					
+								/delay 3
 								| If the item was not selected
 								/if (!${Window[MerchantWnd].Child[MW_SelectedItemLabel].Text.Equal[${Me.Inventory[pack${i}].Item[${e}]}]}) {
 									
-									| If I have time, retry to select the item
-									/if (${retryTimer}) {
-										/goto :retrySelect_Pack
-									} else {
+									| Try again
+									/delay 3
+									/if (!${Window[MerchantWnd].Child[MW_SelectedItemLabel].Text.Equal[${Me.Inventory[pack${i}].Item[${e}]}]}) {
 										/echo ERROR: Failed to select [${Me.Inventory[pack${i}].Item[${e}]}], skipping.
 									}
+									
 								} else {
 						
 									| Check that the buy button is enabled
@@ -326,24 +324,25 @@ SUB sellItems
 						
 										| Sell the item
 										/varset retryTimer 30
-										/echo Selling [${Me.Inventory[pack${i}].Item[${e}]}].
+										/echo [${Time}] Selling from pack [${Me.Inventory[pack${i}].Item[${e}]}].
 										
 										:SellItem_Pack
 										/if (${Debug} || ${Debug_Sell}) /echo |- sellItems -| :SellItem_Pack
 										/notify MerchantWnd MW_Sell_Button leftmouseup
-										/delay ${retryTimer} ${Window[QuantityWnd].Open} || !${Bool[${Me.Inventory[pack${i}].Item[${e}]}]}
-						
+										/delay 1
 										| Close the quantity window
 										/if (${Window[QuantityWnd].Open}) {
 											/notify QuantityWnd QTYW_Accept_Button leftmouseup
-											/delay ${retryTimer} !${Window[QuantityWnd].Open}
-											/delay ${retryTimer} !${Bool[${Me.Inventory[pack${i}]}]}
+											/delay 3
+										} else {
+											|leave a total delay of 3 for client-server communication
+											/delay 2
 										}
-						
+
 										| If the item is still in my inventory
 										/if (${Bool[${Me.Inventory[pack${i}].Item[${e}]}]} && ${retryTimer}) {
 											/goto :SellItem
-										} else {
+										} else /if (${Bool[${Me.Inventory[pack${i}].Item[${e}]}]}) {
 											/echo ERROR: Failed to sell [${Me.Inventory[pack${i}].Item[${e}]}], skipping.
 										}
 									}
@@ -383,17 +382,15 @@ SUB sellItems
 						/if (${Debug} || ${Debug_Sell}) /echo |- sellItems -| :retrySelect
 						/itemnotify in pack${i} leftmouseup
 						
-						/delay ${retryTimer} ${Window[MerchantWnd].Child[MW_SelectedItemLabel].Text.Equal[${Me.Inventory[pack${i}]}]}
-					
+						/delay 3
 						| If the item was not selected
 						/if (!${Window[MerchantWnd].Child[MW_SelectedItemLabel].Text.Equal[${Me.Inventory[pack${i}]}]}) {
 							
-							| If I have time, retry to select the item
-							/if (${retryTimer}) {
-								/goto :retrySelect
-							} else {
+							/delay 3
+							/if (!${Window[MerchantWnd].Child[MW_SelectedItemLabel].Text.Equal[${Me.Inventory[pack${i}]}]}) {
 								/echo ERROR: Failed to select [${Me.Inventory[pack${i}]}], skipping.
 							}
+							
 						} else {
 				
 							| Check that the buy button is enabled
@@ -406,24 +403,29 @@ SUB sellItems
 				
 								| Sell the item
 								/varset retryTimer 30
-								/echo Selling [${Me.Inventory[pack${i}]}].
+								/echo [${Time}] Selling from root [${Me.Inventory[pack${i}]}].
 								
 								:SellItem
 								/if (${Debug} || ${Debug_Sell}) /echo |- sellItems -| :SellItem
 								/notify MerchantWnd MW_Sell_Button leftmouseup
-								/delay ${retryTimer} ${Window[QuantityWnd].Open} || !${Bool[${Me.Inventory[pack${i}]}]}
-				
-								| Close the quantity window
+								|give it a moment to show the qty window
+								/delay 1
+								| Close the quantity window if it opened
+								:CheckQtyWindow
 								/if (${Window[QuantityWnd].Open}) {
 									/notify QuantityWnd QTYW_Accept_Button leftmouseup
-									/delay ${retryTimer} !${Window[QuantityWnd].Open}
-									/delay ${retryTimer} !${Bool[${Me.Inventory[pack${i}]}]}
+									/delay 3
+									/if (${Window[QuantityWnd].Open}) { 
+										/goto :CheckQtyWindow
+									}
+								} else {
+									|leave a total delay of 3 for client-server communication
+									/delay 2
 								}
-								
 								| If the item is still in my inventory
 								/if (${Bool[${Me.Inventory[pack${i}]}]} && ${retryTimer}) {
 									/goto :SellItem
-								} else {
+								} else /if (${Bool[${Me.Inventory[pack${i}]}]}) {
 									/echo ERROR: Failed to sell [${Me.Inventory[pack${i}]}], skipping.
 								}
 							}

--- a/Macros/e3 Includes/e3_Utilities.inc
+++ b/Macros/e3 Includes/e3_Utilities.inc
@@ -571,7 +571,7 @@ SUB BuildSpellArrayBase(ArrayName, NewArrayName, SkipParams)
 			/if (!(${Me.Book[${tmp_castname}]}||${Me.AltAbility[${tmp_castname}]}||${Me.CombatAbility[${tmp_castname}]}||${Me.Ability[${tmp_castname}]})) {
 				
 				|default to item - no way to validate an item thats on my corpse
-				/if (!${FindItem[=${tmp_castname}].ID}) {
+				/if (!${FindItem[${tmp_castname}].ID}) {
 
 					/if (!${Bool[${Me.Inventory[Chest]}]} && !${Me.Platinum}) {
 						/varset reloadOnLoot TRUE
@@ -612,7 +612,7 @@ SUB BuildSpellArrayBase(ArrayName, NewArrayName, SkipParams)
 		} else {
 			/varset ${NewArrayName}[${i},${iCastType}] Item
 		}
-		
+		|/echo ${${NewArrayName}[${i},${iCastName}]} type is: ${${NewArrayName}[${i},${iCastType}]}
 		|set the normal defaults
 		/varset ${NewArrayName}[${i},${iSpellGem}] ${DefaultGem}
 		/varset ${NewArrayName}[${i},${iMaxTries}] 5
@@ -851,9 +851,9 @@ SUB BuildSpellArrayBase(ArrayName, NewArrayName, SkipParams)
 			|Instead of calling FindItem 12 times, we call it twice and get a direct reference to the item in question
 
 			| ${Me.Inventory[23].Item[7].Spell.TargetType}
-			/varset invSlot ${FindItem[=${${NewArrayName}[${i},${iCastName}]}].ItemSlot}
-			/varset bagSlot ${FindItem[=${${NewArrayName}[${i},${iCastName}]}].ItemSlot2}
-
+			/varset invSlot ${FindItem[${${NewArrayName}[${i},${iCastName}]}].ItemSlot}
+			/varset bagSlot ${FindItem[${${NewArrayName}[${i},${iCastName}]}].ItemSlot2}
+			|/echo ${${NewArrayName}[${i},${iCastName}]} inv slot: ${invSlot} bag slot: ${bagSlot}
 			/if (${bagSlot}==-1) {
 				|/echo root item: id:${invSlot} :${${ArrayName}[${i}].Arg[1,/]}
 				|Means this is not in a bag and in the root inventory

--- a/Macros/e3 Macro Inis/General Settings.ini
+++ b/Macros/e3 Macro Inis/General Settings.ini
@@ -32,6 +32,7 @@ Loot After Summoning (On/Off)=Off
 Loot Link Channel=g
 Corpse Seek Radius=50
 Loot In Combat=FALSE
+NumOfFreeSlotsOpen(1+)=0
 Loot Only Stackable: Enable (On/Off)=Off
 Loot Only Stackable: With Value Greater Than Or Equal in Copper=10000
 Loot Only Stackable: Loot common tradeskill items ie:pelts ores silks etc (On/Off)=On

--- a/Macros/e3.mac
+++ b/Macros/e3.mac
@@ -36,6 +36,7 @@ SUB Main(modeSelect)
 		/varset ActionTaken FALSE
     
     /call check_Basics
+    
  		/call check_Active
 		/call check_Idle
     /call check_autoTribute
@@ -47,12 +48,13 @@ SUB Main(modeSelect)
     /if (${reloadOnLoot}) /call reloadSpellArrays
 
 		/call Background_Events
-		| If I'm not active, call mainFunctions
-		/if (!${activeTimer}) {
-      |These are functions in the e3_setup/Advanced.ini class sections... ex CLR Function#1=check_DivineArb
-			
 
-      :restartMainLoopSubLoop
+    |insta buffs are normaly done for junk buffs, be sure to call them often and even when active
+    /if (${Defined[InstantBuffs2D]})	/call buffBotsInstant "InstantBuffs2D"
+    | If I'm not active, call mainFunctions
+   	/if (!${activeTimer}) {
+      |These are functions in the e3_setup/Advanced.ini class sections... ex CLR Function#1=check_DivineArb
+		  :restartMainLoopSubLoop
       |if you are a healer, hard coding a check_heals. This is to deal with sub methods being able to call
       |interrupts for heals and then then ActionTaken is set to true, which may never get to your check_heals
       |all healers should have check_Heals as their #1, this is just making sure it is. 
@@ -93,6 +95,8 @@ SUB Main(modeSelect)
       }
       /if (${medBreak}) /call check_MedBreak
 		}
+    |insta buffs are normaly done for junk buffs, be sure to call them often
+    /if (${Defined[InstantBuffs2D]})	/call buffBotsInstant "InstantBuffs2D"
 
   |**/if (${MoveUtils.GM}) {
     /squelch /stick imsafe

--- a/Macros/e3.mac
+++ b/Macros/e3.mac
@@ -98,10 +98,11 @@ SUB Main(modeSelect)
     |insta buffs are normaly done for junk buffs, be sure to call them often
     /if (${Defined[InstantBuffs2D]})	/call buffBotsInstant "InstantBuffs2D"
 
-  |**/if (${MoveUtils.GM}) {
+  /if (${MoveUtils.GM}) {
     /squelch /stick imsafe
     /echo GM Safe kicked in, issued /stick imsafe.  you may need to reissue /followme or /assiston
-  }**|
+  }
+  
 /if (${Debug}) {
 	/echo <== MainLoop -|
 	/delay 5

--- a/Macros/e3.mac
+++ b/Macros/e3.mac
@@ -10,6 +10,8 @@
 #include e3 Includes\e3_Setup.inc
 
 SUB Main(modeSelect)
+  
+ 
   /declare macroVersion string outer 8.0
   /declare Debug bool outer false
   /declare IniMode string outer Ini
@@ -20,13 +22,14 @@ SUB Main(modeSelect)
   /call e3_Setup "${modeSelect}"
 	/if (${Debug}) {
 		/echo Post Setup
-		/delay 5
+	  /delay 5
 	}
   /declare i int local
-  /declare mainLoop_IsHealer bool local False
+  /declare mainLoop_IsHealer bool outer False
   /if (${Select[${Me.Class.ShortName},CLR,DRU,SHM]}) {
     /varset mainLoop_IsHealer True
   } 
+
 
 :MainLoop
 /if (${Debug}) /echo |- MainLoop ==>


### PR DESCRIPTION
Allow heals to happen during dots
Tons of delay echos to determine why your toons are not doing something.
Modification to heals to check local info + netbots and take the lowest to deal with situations where your healers are not getting proper updates. Aka i died and my healers watched me die.
Loot changes so that you can specify a # of inventory slots to keep free. Note, this does not take into account inventory sizes.
Modification to heals to stay in the heal loop until no action is taken , then release control back to the other events. Basically why leave heals when you have someone else to heal and you are going to come right back here anyway.
Updates/fixes to xtarget clear
Modified insta cast buffs to be a bit more aggressive for tanks/junk buffs
Fix for clickit to not double click on LDON dungeons.