### PR TITLE
Feature/rogue autohide

### DIFF
--- a/Macros/e3 Includes/e3_Classes_Rogue.inc
+++ b/Macros/e3 Includes/e3_Classes_Rogue.inc
@@ -19,12 +19,12 @@ Sub check_rogStrike
 sub AutoHide
 /if (${Debug}) /echo |- AutoHide ==>
 	| Engage sneak.
-	/if (!${Me.Sneaking} && ${Me.AbilityReady[Sneak]} && !${Select[${Zone.ID},${AutoHideSuppress}]}) {
+	/if (!${Me.Sneaking} && ${Me.AbilityReady[Sneak]}) {
 		/doability Sneak
 		/delay 1s ${Me.Sneaking}
 	}
 	| Engage hide.
-	/if (${Me.Sneaking} && ${Me.AbilityReady[Hide]} && !${Select[${Zone.ID},${AutoHideSuppress}]}) {
+	/if (${Me.Sneaking} && ${Me.AbilityReady[Hide]}) {
 		/doability Hide
 		/delay 1s ${Me.Invis}
 	}
@@ -49,12 +49,11 @@ Sub ROG_Setup
 /if (${Debug}) /echo |- ROG_Setup ==>
 	/call iniToVarV "${Character_Ini},Rogue,Auto-Hide (On/Off)" AutoHide bool outer
 	/call iniToVarV "${Character_Ini},Rogue,Auto-Evade (On/Off)" AutoEvade bool outer
-	/call iniToVarV "${Character_Ini},Rogue,Auto-Hide Suppress" AutoHideSuppress string outer
-	/call iniToVarV "${Character_Ini},Rogue,Evade PctAggro" evadePctAggro int outer
-	/call iniToVarV "${Character_Ini},Rogue,Evade PctAggro" evadePctAggro int outer
-	/call iniToVarV "${Character_Ini},Rogue,PoisonPR" poisonPR string outer
-	/call iniToVarV "${Character_Ini},Rogue,PoisonFR" poisonFR string outer
-	/call iniToVarV "${Character_Ini},Rogue,PoisonCR" poisonCR string outer
+	/call iniToVarV "${Character_Ini},Rogue,Auto-Hide Suppress(Zone ID)" AutoHideSuppress string outer
+  /call iniToVarV "${Character_Ini},Rogue,Evade PctAggro" evadePctAggro int outer
+  /call iniToVarV "${Character_Ini},Rogue,PoisonPR" poisonPR string outer
+  /call iniToVarV "${Character_Ini},Rogue,PoisonFR" poisonFR string outer
+  /call iniToVarV "${Character_Ini},Rogue,PoisonCR" poisonCR string outer
 	| Assassin Strikes
 	/call iniToVarV "${Character_Ini},Rogue,Sneak Attack Discipline" strikeDiscStr string outer
 	/if (${Defined[strikeDiscStr]}) {
@@ -83,7 +82,7 @@ SUB ROG_MacroSettings
 SUB ROG_CharacterSettings
 	/if (${Debug}) /echo |- ROG_CharacterSettings ==>
 	/call WriteToIni "${Character_Ini},${Me.Class},Auto-Hide (On/Off)" Off
-	/call WriteToIni "${Character_Ini},${Me.Class},Auto-Hide Suppress" 202,151,386,152
+	/call WriteToIni "${Character_Ini},${Me.Class},Auto-Hide Suppress(Zone ID)" 202,151,386,152,35
 	/call WriteToIni "${Character_Ini},${Me.Class},Auto-Evade (On/Off)" On
 	/call WriteToIni "${Character_Ini},${Me.Class},Evade PctAggro" 75
 	/call WriteToIni "${Character_Ini},${Me.Class},Sneak Attack Discipline"
@@ -97,5 +96,5 @@ Sub ROG_Aliases
 /return
 |----------------------------------------------------------------------------|
 Sub ROG_Background_Events
-	/if (${AutoHide} && !${Me.Invis} && !${Me.Moving} && ${Me.CombatState.NotEqual[COMBAT]}) /call AutoHide
+	/if (${AutoHide} && !${Me.Invis} && !${Me.Moving} && ${Me.CombatState.NotEqual[COMBAT]}  && !${Select[${Zone.ID},${AutoHideSuppress}]}) /call AutoHide
 /return

--- a/Macros/e3 Includes/e3_Classes_Rogue.inc
+++ b/Macros/e3 Includes/e3_Classes_Rogue.inc
@@ -82,7 +82,7 @@ SUB ROG_MacroSettings
 SUB ROG_CharacterSettings
 	/if (${Debug}) /echo |- ROG_CharacterSettings ==>
 	/call WriteToIni "${Character_Ini},${Me.Class},Auto-Hide (On/Off)" Off
-	/call WriteToIni "${Character_Ini},${Me.Class},Auto-Hide Suppress(Zone ID)" 202,151,386,152,35
+	/call WriteToIni "${Character_Ini},${Me.Class},Auto-Hide Suppress(Zone ID)" 202,151,386,152
 	/call WriteToIni "${Character_Ini},${Me.Class},Auto-Evade (On/Off)" On
 	/call WriteToIni "${Character_Ini},${Me.Class},Evade PctAggro" 75
 	/call WriteToIni "${Character_Ini},${Me.Class},Sneak Attack Discipline"

--- a/Macros/e3 Includes/e3_Classes_Rogue.inc
+++ b/Macros/e3 Includes/e3_Classes_Rogue.inc
@@ -19,12 +19,12 @@ Sub check_rogStrike
 sub AutoHide
 /if (${Debug}) /echo |- AutoHide ==>
 	| Engage sneak.
-	/if (!${Me.Sneaking} && ${Me.AbilityReady[Sneak]}) {
+	/if (!${Me.Sneaking} && ${Me.AbilityReady[Sneak]} && !${Select[${Zone.ID},${AutoHideSuppress}]}) {
 		/doability Sneak
 		/delay 1s ${Me.Sneaking}
 	}
 	| Engage hide.
-	/if (${Me.Sneaking} && ${Me.AbilityReady[Hide]}) {
+	/if (${Me.Sneaking} && ${Me.AbilityReady[Hide]} && !${Select[${Zone.ID},${AutoHideSuppress}]}) {
 		/doability Hide
 		/delay 1s ${Me.Invis}
 	}
@@ -49,10 +49,12 @@ Sub ROG_Setup
 /if (${Debug}) /echo |- ROG_Setup ==>
 	/call iniToVarV "${Character_Ini},Rogue,Auto-Hide (On/Off)" AutoHide bool outer
 	/call iniToVarV "${Character_Ini},Rogue,Auto-Evade (On/Off)" AutoEvade bool outer
-  /call iniToVarV "${Character_Ini},Rogue,Evade PctAggro" evadePctAggro int outer
-  /call iniToVarV "${Character_Ini},Rogue,PoisonPR" poisonPR string outer
-  /call iniToVarV "${Character_Ini},Rogue,PoisonFR" poisonFR string outer
-  /call iniToVarV "${Character_Ini},Rogue,PoisonCR" poisonCR string outer
+	/call iniToVarV "${Character_Ini},Rogue,Auto-Hide Suppress" AutoHideSuppress string outer
+	/call iniToVarV "${Character_Ini},Rogue,Evade PctAggro" evadePctAggro int outer
+	/call iniToVarV "${Character_Ini},Rogue,Evade PctAggro" evadePctAggro int outer
+	/call iniToVarV "${Character_Ini},Rogue,PoisonPR" poisonPR string outer
+	/call iniToVarV "${Character_Ini},Rogue,PoisonFR" poisonFR string outer
+	/call iniToVarV "${Character_Ini},Rogue,PoisonCR" poisonCR string outer
 	| Assassin Strikes
 	/call iniToVarV "${Character_Ini},Rogue,Sneak Attack Discipline" strikeDiscStr string outer
 	/if (${Defined[strikeDiscStr]}) {
@@ -81,6 +83,7 @@ SUB ROG_MacroSettings
 SUB ROG_CharacterSettings
 	/if (${Debug}) /echo |- ROG_CharacterSettings ==>
 	/call WriteToIni "${Character_Ini},${Me.Class},Auto-Hide (On/Off)" Off
+	/call WriteToIni "${Character_Ini},${Me.Class},Auto-Hide Suppress" 202,151,386,152
 	/call WriteToIni "${Character_Ini},${Me.Class},Auto-Evade (On/Off)" On
 	/call WriteToIni "${Character_Ini},${Me.Class},Evade PctAggro" 75
 	/call WriteToIni "${Character_Ini},${Me.Class},Sneak Attack Discipline"


### PR DESCRIPTION
Added an INI key for the Rogue that allows you to specify Zones that you do not want Auto-Hide to function.  When the rogue is hidden, certain things like speaking to an NPC, issuing /bc gimme or /bc collect commands may not work without disabling auto-hide or pausing the macro.  

The new INI entry takes a list of ${Zone.ID} values that are comma delimited.  When you're in one of these zones Auto-Hide will not trigger.

[Rogue]
Auto-Hide Suppress(Zone ID)=202,151,386,152