### PR TITLE
Update e3_Background.inc

### DIFF
--- a/Macros/e3 Includes/e3_Background.inc
+++ b/Macros/e3 Includes/e3_Background.inc
@@ -216,7 +216,7 @@ SUB Event_YourKill(line)
       /bc [+y+] Auto setting AA Exp to 100%, at ${Me.PctExp}% of Level ${Me.Level}
     }
   }
-  /if (${Auto_Loot} && (${Me.CombatState.NotEqual[Combat]} || ${combatLooting})) /call loot_Area
+  /if (${Auto_Loot} && (${Me.CombatState.NotEqual[Combat]} && ${SpawnCount[xtarhater radius 100]} == 0 || ${combatLooting})) /call loot_Area
 /RETURN
 
 |----------------------------------------------------------------------------------------------------|


### PR DESCRIPTION
Most auto looting is triggered by the EVENT_YourKill routine.  Me.CombatState doesn't always return the correct value so I put an additional check in to look at how many XTarget haters you have.  When that is zero we'll consider that out of combat and your characters can go ahead and start looting.

My Wizards seem to have the biggest issue with determining combat state and I've run this through a couple days and it seems much more reliable.

Below is the only line that changed, I added a single and condition to the check.  Initially I had this set to the same radius as the loot radius(50), but doubled it because close by mobs might trigger combat soon after xtargets is cleared and you'd get a false positive

/if (${Auto_Loot} && (${Me.CombatState.NotEqual[Combat]} **&& ${SpawnCount[xtarhater radius 100]} == 0** || ${combatLooting})) /call loot_Area