### PR TITLE
Bug/autosell

### DIFF
--- a/Macros/e3 Includes/e3_Background.inc
+++ b/Macros/e3 Includes/e3_Background.inc
@@ -216,7 +216,7 @@ SUB Event_YourKill(line)
       /bc [+y+] Auto setting AA Exp to 100%, at ${Me.PctExp}% of Level ${Me.Level}
     }
   }
-  /if (${Auto_Loot} && (${Me.CombatState.NotEqual[Combat]} || ${combatLooting})) /call loot_Area
+  /if (${Auto_Loot} && (${Me.CombatState.NotEqual[Combat]} && ${SpawnCount[xtarhater radius 100]} == 0 || ${combatLooting})) /call loot_Area
 /RETURN
 
 |----------------------------------------------------------------------------------------------------|

--- a/Macros/e3 Includes/e3_Loot.inc
+++ b/Macros/e3 Includes/e3_Loot.inc
@@ -435,57 +435,56 @@ SUB lootCorpse
 |--------------------------------------------------------------------------|
 SUB get_lootSetting(invSlot, itemSlot)
 |/if (${Debug} || ${Debug_Loot}) /echo |- get_lootSetting invSlot: ${invSlot} ${itemSlot}
-  /if (!${Bool[${Corpse.Items}]} && !${Window[MerchantWnd]}) /return
 	/declare itemName string local
 	/declare itemValue string local
-  /declare itemRawValue int local
+	/declare itemRawValue int local
 	/declare iniEntryVariables string local
 	/varset lootSetting
 	| If the item is not in a bag
 	/if (!${Bool[${itemSlot}]}) {
 		|/echo invSlot variable: ${invSlot} 
-		| Reset itemName if it contains a ':'.  ':'s cause errors when reading from the ini, because they act as a delimiter, just like '='s
-|		/echo ${Corpse.Item[${invSlot}].Name}		
-		/varset itemName ${Corpse.Item[${invSlot}].Name}
+		| Reset itemName if it contains a ':'.  ':'s cause errors when reading from the ini, because they act as a delimiter, just like '='s	
+		/varset itemName ${Me.Inventory[${invSlot}].Name}
 		/if (${itemName.Find[:]}) /varset itemName ${itemName.Replace[:,;]}
-    /if (${itemName.Find[,]}) {
-      /call RemoveComma "${itemName}"
-      /varset itemName ${Macro.Return}
-    }
+		/if (${itemName.Find[,]}) {
+			/call RemoveComma "${itemName}"
+			/varset itemName ${Macro.Return}
+		}
 		| Set item value
-		/varset itemValue ${Corpse.Item[${invSlot}].Value}
-    	/varset itemRawValue ${Corpse.Item[${invSlot}].Value}
+		/varset itemValue ${Me.Inventory[${invSlot}].Value}
+    	/varset itemRawValue ${Me.Inventory[${invSlot}].Value}
     	/varset itemValue ${If[${Bool[${itemValue.Left[${Math.Calc[${itemValue.Length} - 3].Int}]}]},${itemValue.Left[${Math.Calc[${itemValue.Length} - 3].Int}]}p,]}${If[${Bool[${itemValue.Mid[${Math.Calc[${itemValue.Length} - 2].Int}]}]},${itemValue.Mid[${Math.Calc[${itemValue.Length} - 2].Int}]}g,]}${If[${Bool[${itemValue.Mid[${Math.Calc[${itemValue.Length} - 1].Int}]}]},${itemValue.Mid[${Math.Calc[${itemValue.Length} - 1].Int}]}s,]}${If[${Bool[${itemValue.Right[1]}]},${itemValue.Right[1]}c,]}
 		
 		| Set ini variables like stack size, (C), (ND) etc.
-		/varset iniEntryVariables ${If[${Corpse.Item[${invSlot}].Stackable},(${Corpse.Item[${invSlot}].StackSize}),]}${If[${Corpse.Item[${invSlot}].NoDrop},(ND),]}${If[${Corpse.Item[${invSlot}].Lore},(L),]}${If[${Corpse.Item[${invSlot}].Container},(C),]}
+		/varset iniEntryVariables ${If[${Me.Inventory[${invSlot}].Stackable},(${Me.Inventory[${invSlot}].StackSize}),]}${If[${Me.Inventory[${invSlot}].NoDrop},(ND),]}${If[${Me.Inventory[${invSlot}].Lore},(L),]}${If[${Me.Inventory[${invSlot}].Container},(C),]}
 		| Check for a Loot_Ini entry
 		|/echo /if (!{Ini[${Loot_Ini},${itemName.Left[1]},${itemName} ${itemValue}${iniEntryVariables}].Length})
 		/if (!${Ini[${Loot_Ini},${itemName.Left[1]},${itemName} ${itemValue}${iniEntryVariables}].Length}) /echo ifsuccess
 		/if (!${Ini[${Loot_Ini},${itemName.Left[1]},${itemName} ${itemValue}${iniEntryVariables}].Length}) {
-			/echo /call WriteToIni "${Loot_Ini},${itemName.Left[1]},${itemName} ${itemValue}${iniEntryVariables}" ${If[${Corpse.Item[${invSlot}].Container},Container,${If[${Corpse.Item[${invSlot}].NoDrop},Skip,Keep${If[${Corpse.Item[${invSlot}].Stackable},|${Corpse.Item[${invSlot}].StackSize},]}]}]}
-			/call WriteToIni "${Loot_Ini},${itemName.Left[1]},${itemName} ${itemValue}${iniEntryVariables}" ${If[${Corpse.Item[${invSlot}].Container},Container,${If[${Corpse.Item[${invSlot}].NoDrop},Skip,Keep${If[${Corpse.Item[${invSlot}].Stackable},|${Corpse.Item[${invSlot}].StackSize},]}]}]}
-			/echo /docommand ${ChatToggle} Added: [${Corpse.Item[${invSlot}].Name}(${Ini[${Loot_Ini},${itemName.Left[1]},${itemName} ${itemValue}${iniEntryVariables}]})] to [${Loot_Ini}].
-			/docommand ${ChatToggle} Added: [${Corpse.Item[${invSlot}].Name}(${Ini[${Loot_Ini},${itemName.Left[1]},${itemName} ${itemValue}${iniEntryVariables}]})] to [${Loot_Ini}].
+			/echo /call WriteToIni "${Loot_Ini},${itemName.Left[1]},${itemName} ${itemValue}${iniEntryVariables}" ${If[${Me.Inventory[${invSlot}].Container},Container,${If[${Me.Inventory[${invSlot}].NoDrop},Skip,Keep${If[${Me.Inventory[${invSlot}].Stackable},|${Me.Inventory[${invSlot}].StackSize},]}]}]}
+			/call WriteToIni "${Loot_Ini},${itemName.Left[1]},${itemName} ${itemValue}${iniEntryVariables}" ${If[${Me.Inventory[${invSlot}].Container},Container,${If[${Me.Inventory[${invSlot}].NoDrop},Skip,Keep${If[${Me.Inventory[${invSlot}].Stackable},|${Me.Inventory[${invSlot}].StackSize},]}]}]}
+			/echo /docommand ${ChatToggle} Added: [${Me.Inventory[${invSlot}].Name}(${Ini[${Loot_Ini},${itemName.Left[1]},${itemName} ${itemValue}${iniEntryVariables}]})] to [${Loot_Ini}].
+			/docommand ${ChatToggle} Added: [${Me.Inventory[${invSlot}].Name}(${Ini[${Loot_Ini},${itemName.Left[1]},${itemName} ${itemValue}${iniEntryVariables}]})] to [${Loot_Ini}].
 		}
 	| If the item is in a bag
 	} else {
 		| Reset itemName if it contains a ':'.  ':'s cause errors when reading from the ini, because they act as a delimiter, just like '='s
 		/varset itemName ${Me.Inventory[${invSlot}].Item[${itemSlot}].Name}
 		/if (${itemName.Find[:]}) /varset itemName ${itemName.Replace[:,;]}
-    /if (${itemName.Find[,]}) {
-      /call RemoveComma "${itemName}"
-      /varset itemName ${Macro.Return}
-    }
+		/if (${itemName.Find[,]}) {
+		  /call RemoveComma "${itemName}"
+		  /varset itemName ${Macro.Return}
+		}
 		| Set item value
 		/varset itemValue ${Me.Inventory[${invSlot}].Item[${itemSlot}].Value}
 		/varset itemValue ${If[${Bool[${itemValue.Left[${Math.Calc[${itemValue.Length} - 3].Int}]}]},${itemValue.Left[${Math.Calc[${itemValue.Length} - 3].Int}]}p,]}${If[${Bool[${itemValue.Mid[${Math.Calc[${itemValue.Length} - 2].Int}]}]},${itemValue.Mid[${Math.Calc[${itemValue.Length} - 2].Int}]}g,]}${If[${Bool[${itemValue.Mid[${Math.Calc[${itemValue.Length} - 1].Int}]}]},${itemValue.Mid[${Math.Calc[${itemValue.Length} - 1].Int}]}s,]}${If[${Bool[${itemValue.Right[1]}]},${itemValue.Right[1]}c,]}
 		| Set ini variables like stack size, (C), (ND) etc.
 		/varset iniEntryVariables ${If[${Me.Inventory[${invSlot}].Item[${itemSlot}].Stackable},(${Me.Inventory[${invSlot}].Item[${itemSlot}].StackSize}),]}${If[${Me.Inventory[${invSlot}].Item[${itemSlot}].NoDrop},(ND),]}${If[${Me.Inventory[${invSlot}].Item[${itemSlot}].Lore},(L),]}${If[${Me.Inventory[${invSlot}].Item[${itemSlot}].Container},(C),]}
+
 		| Check for a Loot_Ini entry
 		/if (!${Ini[${Loot_Ini},${itemName.Left[1]},${itemName} ${itemValue}${iniEntryVariables}].Length}) {
 			
-      /if (!(${LootOnlyStackableEnabled} &&  !${Me.Inventory[${invSlot}].Item[${itemSlot}].Stackable})) {
+		/if (!(${LootOnlyStackableEnabled} &&  !${Me.Inventory[${invSlot}].Item[${itemSlot}].Stackable})) {
         /call WriteToIni "${Loot_Ini},${itemName.Left[1]},${itemName} ${itemValue}${iniEntryVariables}" ${If[${Me.Inventory[${invSlot}].Item[${itemSlot}].Container},Container,${If[${Me.Inventory[${invSlot}].Item[${itemSlot}].NoDrop},Skip,Keep${If[${Me.Inventory[${invSlot}].Item[${itemSlot}].Stackable},|${Me.Inventory[${invSlot}].Item[${itemSlot}].StackSize},]}]}]}
         /docommand ${ChatToggle} Added: [${Me.Inventory[${invSlot}].Item[${itemSlot}].Name}(${Ini[${Loot_Ini},${itemName.Left[1]},${itemName} ${itemValue}${iniEntryVariables}]})] to [${Loot_Ini}].
       }

--- a/Macros/e3 Includes/e3_Sell.inc
+++ b/Macros/e3 Includes/e3_Sell.inc
@@ -442,7 +442,7 @@ Sub sellItems
 Sub destroyItems
 /if (${Debug} || ${Debug_Sell}) /echo |- destroyItems ==>
 	/declare i int local
-	/declare maxClickAttempts int local 5
+	/declare maxClickAttempts int local 10
 	/declare clickAttempts int local 0
 	
 	/echo Destroying Items
@@ -464,13 +464,8 @@ Sub destroyItems
 			} else {
 				/itemnotify in pack${packArray[${i}]} ${slotArray[${i}]} leftmouseup
 			}
-			/delay 1
-			/if (!${Cursor.ID} && (${clickAttempts} < ${maxClickAttempts})) {
-				/varset clickAttempts ${Math.Calc[${clickAttempts}+1]}
-				/goto :selectItemAgain
-			}
-			/if (${clickAttempts} >= ${maxClickAttempts}) /echo Max clickAttempts reached on :selectItemAgain
-			/delay 1
+			/delay 1	
+			
 			/varset clickAttempts 0
 			:clickQuantityAgain
 			/if (${Window[QuantityWnd].Open} && (${clickAttempts} < ${maxClickAttempts})) {
@@ -480,6 +475,13 @@ Sub destroyItems
 				/goto :clickQuantityAgain
 			}
 			/if (${clickAttempts} >= ${maxClickAttempts}) /echo Max clickAttempts reached on :clickQuantityAgain
+			
+			/if (!${Cursor.ID} && (${clickAttempts} < ${maxClickAttempts})) {
+				/varset clickAttempts ${Math.Calc[${clickAttempts}+1]}
+				/goto :selectItemAgain
+			}
+			/if (${clickAttempts} >= ${maxClickAttempts}) /echo Max clickAttempts reached on :selectItemAgain
+			/delay 1			
 			/destroy
 			/delay 3
 			/autoinventory

--- a/Macros/e3 Includes/e3_Sell.inc
+++ b/Macros/e3 Includes/e3_Sell.inc
@@ -349,9 +349,12 @@ SUB closeMerchant
 /if (${Debug} || ${Debug_Sell}) /echo <== closeMerchant -|
 /RETURN
 
-|----------------------------------------------------------------------------------------|
+|-----------------------------------------------------------------------------------------------------------------------------------------|
 |- Create an array of your inventory
-|----------------------------------------------------------------------------------------|
+|-----------------------------------------------------------------------------------------------------------------------------------------|
+| Scan Inventory creates arrays of your inventory so that the code is a bit more readable.  Iterating inventory typically takes two passes
+| one pass for containers and one pass for inventory slots.  The array just stores the location types so we do a single loop and try to 
+| make the code a bit more readable.  Scan inventory will only keep track of items and ignores empty slots.
 sub ScanInventory
 /if (${Debug} || ${Debug_Sell}) /echo |- ScanInventory ==>
 	/declare i int local
@@ -360,6 +363,7 @@ sub ScanInventory
 	/declare containerSize int local
 	/if (${Defined[packArray]}) { /deletevar packArray }
 	/if (${Defined[slotArray]}) { /deletevar slotArray }
+	/if (${Defined[itemNameArray]}) { /deletevar itemNameArray }
 	
 	/echo Scanning Inventory
 	/for i 1 to ${numInventorySlots} {
@@ -371,12 +375,14 @@ sub ScanInventory
 				/if (${Bool[${Me.Inventory[${invSlot}].Item[${j}]}]}) {
 					/call BuildArray packArray ${i}
 					/call BuildArray slotArray ${j}
+					/call BuildArray itemNameArray "${Me.Inventory[${invSlot}].Item[${j}].Name}"
 				}
 			/next j
 		} else {
 			/if (${Bool[${Me.Inventory[${invSlot}]}]}) {
 				/call BuildArray packArray ${i}
 				/call BuildArray slotArray 0
+				/call BuildArray itemNameArray "${Me.Inventory[${invSlot}].Name}"
 			}
 		}
 	/next i
@@ -386,21 +392,26 @@ sub ScanInventory
 Sub sellItems
 /if (${Debug} || ${Debug_Sell}) /echo |- ScanInventory ==>
 	/declare i int local
+	| maxClickAttempts is our retry counter.  Latency causes things not to work so we will retry a certain number of times to do our best to make sure items get sold or destroyed
 	/declare maxClickAttempts int local 10
 	/declare clickAttempts int local 0
 	
 	/echo Selling Items
+	
+	| Scan your inventory into your pack and slot arrays
 	/call ScanInventory
+	
+	| If your inventory is empty just jump out
 	/if (${packArray.Size} == 0) /goto sellEmptyInventory
+	
+	| Loop through all items that we scanned into the array
 	/for i 1 to ${packArray.Size} {
 		/call get_lootSetting pack${packArray[${i}]} ${slotArray[${i}]}
-		/if (${lootSetting.Find[Sell]}) {
-			/if (${slotArray[${i}].Equal[0]}) {
-				/echo Selling: ${Me.Inventory[${Math.Calc[${packArray[${i}]}+22]}]} 
-			} else {
-				/echo Selling: ${Me.Inventory[${Math.Calc[${packArray[${i}]}+22]}].Item[${Math.Calc[${slotArray[${i}]}]}]}
-			}
+		/if (${lootSetting.Find[Sell]}) {	
+			/echo Selling: ${itemNameArray[${i}]}
+
 			/varset clickAttempts 0
+			| With the merchant window open, we'll left click the items to add them to the merchant sell window
 			:selectItemAgain
 			/if (${slotArray[${i}].Equal[0]}) {
 				/itemnotify ${Math.Calc[${packArray[${i}]}+22]} leftmouseup
@@ -408,14 +419,21 @@ Sub sellItems
 				/itemnotify in pack${packArray[${i}]} ${slotArray[${i}]} leftmouseup
 			}
 			/delay 1
+	
+			| Check to see if the sell button is enabled once the merchant window is open
 			/if (!${Window[MerchantWnd].Child[MW_Sell_Button].Enabled} && (${clickAttempts} < ${maxClickAttempts})) {
 				/varset clickAttempts ${Math.Calc[${clickAttempts}+1]}
 				/goto :selectItemAgain
 			}
-			/if (${clickAttempts} >= ${maxClickAttempts}) /echo Max clickAttempts reached on :selectItemAgain ${i}
+			
+			| If we hit max click attempts print this message for now.  Probably move this to a debug only message eventually.
+			/if (${clickAttempts} >= ${maxClickAttempts}) /echo Max clickAttempts reached on :selectItemAgain ${itemNameArray[${i}]}
+			
+			| The item should be in the merchant window at this point, and the sell button is enabled, so let's click the sell button
+			| we're trying to sell with Shift key held down so that we don't get the quantity window
 			/varset clickAttempts 0
 			:pressSellAgain
-			/notify MerchantWnd MW_Sell_Button leftmouseup
+			/shiftkey /notify MerchantWnd MW_Sell_Button leftmouseup
 			/delay 1
 			/if (${Window[MerchantWnd].Child[MW_Sell_Button].Enabled} && !${Window[QuantityWnd].Open} && (${clickAttempts} < ${maxClickAttempts})) {
 				/varset clickAttempts ${Math.Calc[${clickAttempts}+1]}
@@ -425,7 +443,9 @@ Sub sellItems
 			/delay 1
 			/varset clickAttempts 0
 			:clickQuantityAgain
+			| We used /shiftkey so hopefully the quantity window doesn't come up, but let's check just in case.
 			/if (${Window[QuantityWnd].Open} && (${clickAttempts} < ${maxClickAttempts})) {
+				/echo Quantity window popped up.
 				/notify QuantityWnd QTYW_Accept_Button leftmouseup
 				/delay 1
 				/varset clickAttempts ${Math.Calc[${clickAttempts}+1]}
@@ -451,18 +471,14 @@ Sub destroyItems
 	/for i 1 to ${packArray.Size} {
 		/call get_lootSetting pack${packArray[${i}]} ${slotArray[${i}]}
 		/if (${lootSetting.Find[Destroy]}) {
-			/if (${slotArray[${i}].Equal[0]}) {
-				/echo Destroying Item: ${Me.Inventory[${Math.Calc[${packArray[${i}]}+22]}]}
-			} else {
-				/echo Destroying Item: ${Me.Inventory[${Math.Calc[${packArray[${i}]}+22]}].Item[${Math.Calc[${slotArray[${i}]}]}]}
-			}
+			/echo Destroying: ${itemNameArray[${i}]}
 			
 			/varset clickAttempts 0
 			:selectItemAgain
 			/if (${slotArray[${i}].Equal[0]}) {
-				/itemnotify ${Math.Calc[${packArray[${i}]}+22]} leftmouseup
+				/shiftkey /itemnotify ${Math.Calc[${packArray[${i}]}+22]} leftmouseup
 			} else {
-				/itemnotify in pack${packArray[${i}]} ${slotArray[${i}]} leftmouseup
+				/shiftkey /itemnotify in pack${packArray[${i}]} ${slotArray[${i}]} leftmouseup
 			}
 			/delay 1	
 			

--- a/Macros/e3 Includes/e3_Sell.inc
+++ b/Macros/e3 Includes/e3_Sell.inc
@@ -396,11 +396,11 @@ Sub sellItems
 	/declare maxClickAttempts int local 10
 	/declare clickAttempts int local 0
 	
-	/echo Selling Items ${GameTime.Time12}
+	/echo Selling Items ${GameTime.Time12} --- ${GameTime.SecondsSinceMidnight}
 	
 	| Scan your inventory into your pack and slot arrays
 	/call ScanInventory
-	/echo ScanInventory Complete ${GameTime.Time12}
+	/echo ScanInventory Complete ${GameTime.Time12} --- ${GameTime.SecondsSinceMidnight}
 	
 	| If your inventory is empty just jump out
 	/if (${packArray.Size} == 0) /goto sellEmptyInventory
@@ -457,7 +457,7 @@ Sub sellItems
 		}
 	/next i
 	:sellEmptyInventory
-	/echo Sell Inventory Complete ${GameTime.Time12}
+	/echo Sell Inventory Complete ${GameTime.Time12} --- ${GameTime.SecondsSinceMidnight}
 /if (${Debug} || ${Debug_Sell}) /echo <== sellItems -|
 /return
 

--- a/Macros/e3 Includes/e3_Sell.inc
+++ b/Macros/e3 Includes/e3_Sell.inc
@@ -428,7 +428,7 @@ Sub sellItems
 	/echo ScanInventory Complete ${GameTime.Time12} --- ${GameTime.SecondsSinceMidnight}
 	
 	| If your inventory is empty just jump out
-	/if (${packArray.Size} == 0) /goto sellEmptyInventory
+	/if (${packArray.Size} == 0) /goto :sellEmptyInventory
 	
 	| Loop through all items that we scanned into the array
 	/for i 1 to ${packArray.Size} {

--- a/Macros/e3 Includes/e3_Sell.inc
+++ b/Macros/e3 Includes/e3_Sell.inc
@@ -350,274 +350,146 @@ SUB closeMerchant
 /RETURN
 
 |----------------------------------------------------------------------------------------|
-|- Sells items in your inventory that have been flagged as [/Sell] in your Loot_Ini.	-|
+|- Create an array of your inventory
 |----------------------------------------------------------------------------------------|
-SUB sellItems
-/if (${Debug} || ${Debug_Sell}) /echo |- sellItems ==>
-	/declare retryTimer timer local
+sub ScanInventory
+/if (${Debug} || ${Debug_Sell}) /echo |- ScanInventory ==>
 	/declare i int local
-	/declare e int local
+	/declare j int local
+	/declare invSlot int local
+	/declare containerSize int local
+	/if (${Defined[packArray]}) { /deletevar packArray }
+	/if (${Defined[slotArray]}) { /deletevar slotArray }
 	
-	| Scan inventory for items to sell
-	/for i 1 to ${numInventorySlots}
-	
-		/if (${Bool[${Me.Inventory[pack${i}]}]}) {
+	/echo Scanning Inventory
+	/for i 1 to ${numInventorySlots} {
+		/varcalc invSlot ${Math.Calc[${i}+22]}
 		
-			| If the item in pack slot 'i' IS a container
-			/if (${Me.Inventory[pack${i}].Container}) {
-			
-				| Look at each bag slot for items to sell
-				/for e 1 to ${Me.Inventory[pack${i}].Container}
-				
-					/if (${Bool[${Me.Inventory[pack${i}].Item[${e}]}]}) {
-					
-						| Get the loot setting for the item in pack slot 'i' slot 'e'
-						/call get_lootSetting "pack${i}" "${e}"
-					
-						| Destroy the item
-						/if (${lootSetting.Find[Destroy]}) {
-							/echo Flagging [${Me.Inventory[pack${i}].Item[${e}]}] to be destroyed...
-							/call BuildArray DestroyableItems "${Me.Inventory[pack${i}].Item[${e}]}"
-						
-						| Sell the item
-						} else /if (${lootSetting.Find[Sell]}) {
-					
-							| Check that the item has value.
-							/if (!${Me.Inventory[pack${i}].Item[${e}].Value}) {
-								/if (${destroyUnsold}) {
-									/echo [${Target.CleanName}] will not buy [${Me.Inventory[pack${i}].Item[${e}]}].  Flagging it to be destroyed.
-									/call BuildArray DestroyableItems "${Me.Inventory[pack${i}].Item[${e}]}"
-								}
-							} else {
-					
-								| Select the item to sell
-								/varset retryTimer 30
-
-								:retrySelect_Pack
-								/if (${Debug} || ${Debug_Sell}) /echo |- sellItems -| :retrySelect_Pack
-								/itemnotify in pack${i} ${e} leftmouseup
-								/delay 3
-								| If the item was not selected
-								/if (!${Window[MerchantWnd].Child[MW_SelectedItemLabel].Text.Equal[${Me.Inventory[pack${i}].Item[${e}]}]}) {
-									
-									| Try again
-									/delay 3
-									/if (!${Window[MerchantWnd].Child[MW_SelectedItemLabel].Text.Equal[${Me.Inventory[pack${i}].Item[${e}]}]}) {
-										/echo ERROR: Failed to select [${Me.Inventory[pack${i}].Item[${e}]}], skipping.
-									}
-									
-								} else {
-						
-									| Check that the buy button is enabled
-									/if (!${Window[MerchantWnd].Child[MW_Sell_Button].Enabled}) {
-										/if (${destroyUnsold}) {
-											/echo [${Target.CleanName}] will not buy [${Me.Inventory[pack${i}].Item[${e}]}].  Flagging it to be destroyed.
-											/call BuildArray DestroyableItems "${Me.Inventory[pack${i}].Item[${e}]}"
-										}
-									} else {
-						
-										| Sell the item
-										/varset retryTimer 30
-										/echo [${Time}] Selling from pack [${Me.Inventory[pack${i}].Item[${e}]}].
-										
-										:SellItem_Pack
-										/if (${Debug} || ${Debug_Sell}) /echo |- sellItems -| :SellItem_Pack
-										/notify MerchantWnd MW_Sell_Button leftmouseup
-										/delay 1
-										| Close the quantity window
-										/if (${Window[QuantityWnd].Open}) {
-											/notify QuantityWnd QTYW_Accept_Button leftmouseup
-											/delay 3
-										} else {
-											|leave a total delay of 3 for client-server communication
-											/delay 2
-										}
-
-										| If the item is still in my inventory
-										/if (${Bool[${Me.Inventory[pack${i}].Item[${e}]}]} && ${retryTimer}) {
-											/goto :SellItem
-										} else /if (${Bool[${Me.Inventory[pack${i}].Item[${e}]}]}) {
-											/echo ERROR: Failed to sell [${Me.Inventory[pack${i}].Item[${e}]}], skipping.
-										}
-									}
-								}
-							}
-						}
-					}
-				
-				/next e
-			
-			| If the item in pack slot 'i' is NOT a container
-			} else {
-			
-				| Get the loot setting for the item in pack slot 'i'
-				/call get_lootSetting "pack${i}" 0
-			
-				| Destroy the item
-				/if (${lootSetting.Find[Destroy]}) {
-					/echo Flagging [${InvSlot[pack${i}].Item.Name}] to be destroyed...
-					/call BuildArray DestroyableItems "${InvSlot[pack${i}].Item.Name}"
-				
-				| Sell the item
-				} else /if (${lootSetting.Find[Sell]}) {
-				
-					| Check that the item has value
-					/if (!${Me.Inventory[pack${i}].Item.Value}) {
-						/if (${destroyUnsold}) {
-							/echo [${Target.CleanName}] will not buy [${Me.Inventory[pack${i}].Item.Name}].  Flagging it to be destroyed.
-							/call BuildArray DestroyableItems "${Me.Inventory[pack${i}].Item.Name}"
-						}
-					} else {
-				
-						| Select the item to sell
-						/varset retryTimer 30
-
-						:retrySelect
-						/if (${Debug} || ${Debug_Sell}) /echo |- sellItems -| :retrySelect
-						/itemnotify in pack${i} leftmouseup
-						
-						/delay 3
-						| If the item was not selected
-						/if (!${Window[MerchantWnd].Child[MW_SelectedItemLabel].Text.Equal[${Me.Inventory[pack${i}]}]}) {
-							
-							/delay 3
-							/if (!${Window[MerchantWnd].Child[MW_SelectedItemLabel].Text.Equal[${Me.Inventory[pack${i}]}]}) {
-								/echo ERROR: Failed to select [${Me.Inventory[pack${i}]}], skipping.
-							}
-							
-						} else {
-				
-							| Check that the buy button is enabled
-							/if (!${Window[MerchantWnd].Child[MW_Sell_Button].Enabled}) {
-								/if (${destroyUnsold}) {
-									/echo [${Target.CleanName}] will not buy [${Me.Inventory[pack${i}]}].  Flagging it to be destroyed.
-									/call BuildArray DestroyableItems "${Me.Inventory[pack${i}]}"
-								}
-							} else {
-				
-								| Sell the item
-								/varset retryTimer 30
-								/echo [${Time}] Selling from root [${Me.Inventory[pack${i}]}].
-								
-								:SellItem
-								/if (${Debug} || ${Debug_Sell}) /echo |- sellItems -| :SellItem
-								/notify MerchantWnd MW_Sell_Button leftmouseup
-								|give it a moment to show the qty window
-								/delay 1
-								| Close the quantity window if it opened
-								:CheckQtyWindow
-								/if (${Window[QuantityWnd].Open}) {
-									/notify QuantityWnd QTYW_Accept_Button leftmouseup
-									/delay 3
-									/if (${Window[QuantityWnd].Open}) { 
-										/goto :CheckQtyWindow
-									}
-								} else {
-									|leave a total delay of 3 for client-server communication
-									/delay 2
-								}
-								| If the item is still in my inventory
-								/if (${Bool[${Me.Inventory[pack${i}]}]} && ${retryTimer}) {
-									/goto :SellItem
-								} else /if (${Bool[${Me.Inventory[pack${i}]}]}) {
-									/echo ERROR: Failed to sell [${Me.Inventory[pack${i}]}], skipping.
-								}
-							}
-						}
-					}
+		/if (${Bool[${Me.Inventory[${invSlot}].Container}]}) {
+			/varset containerSize ${Me.Inventory[${invSlot}].Container}
+			/for j 1 to ${containerSize}
+				/if (${Bool[${Me.Inventory[${invSlot}].Item[${j}]}]}) {
+					/call BuildArray packArray ${i}
+					/call BuildArray slotArray ${j}
 				}
+			/next j
+		} else {
+			/if (${Bool[${Me.Inventory[${invSlot}]}]}) {
+				/call BuildArray packArray ${i}
+				/call BuildArray slotArray 0
 			}
 		}
-		
 	/next i
-
 /if (${Debug} || ${Debug_Sell}) /echo <== sellItems -|
-/RETURN
+/Return
 
-SUB destroyItems
-/if (${Debug} || ${Debug_Sell}) /echo |- destroyItem ==>
-	
+Sub sellItems
+/if (${Debug} || ${Debug_Sell}) /echo |- ScanInventory ==>
 	/declare i int local
-	/declare e int local
-	/declare y int local
+	/declare maxClickAttempts int local 5
+	/declare clickAttempts int local 0
 	
-	/declare retryTimer timer local
-	/declare badItem string local
-	
-	/for i 1 to ${DestroyableItems.Size}
-	
-		/varset badItem ${DestroyableItems[${i}]}
-
-		/for e 1 to ${numInventorySlots}
-		
-			/if (!${Me.Inventory[pack${e}].Container}) {
-				
-				/if (${badItem.Equal[${Me.Inventory[pack${e}]}]}) {
-					/varset retryTimer 50
-					
-					:retry_SlotPickup
-					/itemnotify pack${e} leftmouseup
-					/delay 5 ${Cursor.ID} || ${Window[QuantityWnd].Open}
-					
-					| If the quantity window is open.
-					/if (${Window[QuantityWnd].Open}) {
-						/notify QuantityWnd QTYW_Accept_Button leftmouseup
-						/delay 10 !${Window[QuantityWnd].Open}
-					}
-					
-					/delay 5 ${Cursor.ID}
-					
-					/if (${badItem.Equal[${Cursor}]}) {
-						/echo Destroying [${Cursor}].
-						/destroy
-					} else {
-						/if (${retryTimer}) {
-							/goto :retry_SlotPickup
-						} else {
-							/echo ERROR: I failed to destroy [${badItem}], skipping.
-						}
-					}
-				}
+	/echo Selling Items
+	/call ScanInventory
+	/for i 1 to ${packArray.Size} {
+		/call get_lootSetting pack${packArray[${i}]} ${slotArray[${i}]}
+		/if (${slotArray[${i}].Equal[0]}) {
+			|/echo Item: ${Me.Inventory[${Math.Calc[${packArray[${i}]}+22]}]} --- ${lootSetting}
+		} else {
+			|/echo Item: ${Me.Inventory[${Math.Calc[${packArray[${i}]}+22]}].Item[${Math.Calc[${slotArray[${i}]}]}]} --- ${lootSetting}
+		}
+		/if (${lootSetting.Find[Sell]}) {
+			/if (${slotArray[${i}].Equal[0]}) {
+				|/echo Selling Item: ${Me.Inventory[${Math.Calc[${packArray[${i}]}+22]}]}
 			} else {
-			
-				/for y 1 to ${Me.Inventory[pack${e}].Container}
-				
-					/if (${badItem.Equal[${Me.Inventory[pack${e}].Item[${y}]}]}) {
-					
-						/varset retryTimer 50
-					
-						:retry_BagPickup
-						/itemnotify in pack${e} ${y} leftmouseup
-						/delay 5 ${Cursor.ID} || ${Window[QuantityWnd].Open}
-						
-						| If the quantity window is open.
-						/if (${Window[QuantityWnd].Open}) {
-							/notify QuantityWnd QTYW_Accept_Button leftmouseup
-							/delay 10 !${Window[QuantityWnd].Open}
-						}
-						
-						/delay 5 ${Cursor.ID}
-						
-						/if (${badItem.Equal[${Cursor}]}) {
-							/echo Destroying [${Cursor}].
-							/destroy
-						} else {
-							/if (${retryTimer}) {
-								/goto :retry_BagPickup
-							} else {
-								/echo ERROR: I failed to destroy [${badItem}], skipping.
-							}
-						}
-					}
-				/next y
+				|/echo Selling Item: ${Me.Inventory[${Math.Calc[${packArray[${i}]}+22]}].Item[${Math.Calc[${slotArray[${i}]}]}]}
 			}
-		
-		/next e
-		
+			
+			/varset clickAttempts 0
+			:selectItemAgain
+			/if (${slotArray[${i}].Equal[0]}) {
+				/itemnotify ${Math.Calc[${packArray[${i}]}+22]} leftmouseup
+			} else {
+				/itemnotify in pack${packArray[${i}]} ${slotArray[${i}]} leftmouseup
+			}
+			/delay 1
+			/if (!${Window[MerchantWnd].Child[MW_Sell_Button].Enabled} && (${clickAttempts} < ${maxClickAttempts})) {
+				/varset clickAttempts ${Math.Calc[${clickAttempts}+1]}
+				/goto :selectItemAgain
+			}
+			/varset clickAttempts 0
+			:pressSellAgain
+			/notify MerchantWnd MW_Sell_Button leftmouseup
+			/delay 1
+			/if (${Window[MerchantWnd].Child[MW_Sell_Button].Enabled} && !${Window[QuantityWnd].Open} && (${clickAttempts} < ${maxClickAttempts})) {
+				/varset clickAttempts ${Math.Calc[${clickAttempts}+1]}
+				/goto :pressSellAgain
+			}
+			/delay 1
+			/varset clickAttempts 0
+			:clickQuantityAgain
+			/if (${Window[QuantityWnd].Open} && (${clickAttempts} < ${maxClickAttempts})) {
+				/notify QuantityWnd QTYW_Accept_Button leftmouseup
+				/delay 1
+				/varset clickAttempts ${Math.Calc[${clickAttempts}+1]}
+				/goto :clickQuantityAgain
+			}
+			/delay 3
+		}
 	/next i
+/if (${Debug} || ${Debug_Sell}) /echo <== sellItems -|
+/return
 
-/if (${Debug} || ${Debug_Sell}) /echo <== destroyItem -|
-/RETURN
+Sub destroyItems
+/if (${Debug} || ${Debug_Sell}) /echo |- destroyItems ==>
+	/declare i int local
+	/declare maxClickAttempts int local 5
+	/declare clickAttempts int local 0
+	
+	/call ScanInventory
+	/echo Destroying Items
+	/for i 1 to ${packArray.Size} {
+		/call get_lootSetting pack${packArray[${i}]} ${slotArray[${i}]}
+		/if (${slotArray[${i}].Equal[0]}) {
+			|/echo Item: ${Me.Inventory[${Math.Calc[${packArray[${i}]}+22]}]} --- ${lootSetting}
+		} else {
+			|/echo Item: ${Me.Inventory[${Math.Calc[${packArray[${i}]}+22]}].Item[${Math.Calc[${slotArray[${i}]}]}]} --- ${lootSetting}
+		}
+		/if (${lootSetting.Find[Destroy]}) {
+			/if (${slotArray[${i}].Equal[0]}) {
+				/echo Destroying Item: ${Me.Inventory[${Math.Calc[${packArray[${i}]}+22]}]}
+			} else {
+				/echo Destroying Item: ${Me.Inventory[${Math.Calc[${packArray[${i}]}+22]}].Item[${Math.Calc[${slotArray[${i}]}]}]}
+			}
+			
+			/varset clickAttempts 0
+			:selectItemAgain
+			/if (${slotArray[${i}].Equal[0]}) {
+				/itemnotify ${Math.Calc[${packArray[${i}]}+22]} leftmouseup
+			} else {
+				/itemnotify in pack${packArray[${i}]} ${slotArray[${i}]} leftmouseup
+			}
+			/delay 1
+			/if (!${Cursor.ID} && (${clickAttempts} < ${maxClickAttempts})) {
+				/varset clickAttempts ${Math.Calc[${clickAttempts}+1]}
+				/goto :selectItemAgain
+			}
+			/delay 1
+			/varset clickAttempts 0
+			:clickQuantityAgain
+			/if (${Window[QuantityWnd].Open} && (${clickAttempts} < ${maxClickAttempts})) {
+				/notify QuantityWnd QTYW_Accept_Button leftmouseup
+				/delay 1
+				/varset clickAttempts ${Math.Calc[${clickAttempts}+1]}
+				/goto :clickQuantityAgain
+			}
+			/destroy
+			/delay 3
+			/autoinventory
+		}
+	/next i
+/if (${Debug} || ${Debug_Sell}) /echo <== destroyItems -|
+/return
 
 SUB sell_Setup
 	/call iniToVarV "${advSettings_Ini},Debug,Debug Sell (On/Off)" Debug_Sell bool outer

--- a/Macros/e3 Includes/e3_Sell.inc
+++ b/Macros/e3 Includes/e3_Sell.inc
@@ -434,7 +434,6 @@ Sub sellItems
 	/for i 1 to ${packArray.Size} {
 		/call get_lootSetting pack${packArray[${i}]} ${slotArray[${i}]}
 		/if (${lootSetting.Find[Sell]}) {	
-			/echo Selling: ${itemNameArray[${i}]}
 
 			/varset clickAttempts 0
 			| With the merchant window open, we'll left click the items to add them to the merchant sell window
@@ -498,7 +497,6 @@ Sub destroyItems
 	/for i 1 to ${packArray.Size} {
 		/call get_lootSetting pack${packArray[${i}]} ${slotArray[${i}]}
 		/if (${lootSetting.Find[Destroy]}) {
-			/echo Destroying: ${itemNameArray[${i}]}
 			
 			/varset clickAttempts 0
 			:selectItemAgain

--- a/Macros/e3 Includes/e3_Sell.inc
+++ b/Macros/e3 Includes/e3_Sell.inc
@@ -386,19 +386,20 @@ sub ScanInventory
 Sub sellItems
 /if (${Debug} || ${Debug_Sell}) /echo |- ScanInventory ==>
 	/declare i int local
-	/declare maxClickAttempts int local 5
+	/declare maxClickAttempts int local 10
 	/declare clickAttempts int local 0
 	
 	/echo Selling Items
 	/call ScanInventory
+	/if (${packArray.Size} == 0) /goto sellEmptyInventory
 	/for i 1 to ${packArray.Size} {
 		/call get_lootSetting pack${packArray[${i}]} ${slotArray[${i}]}
-		/if (${slotArray[${i}].Equal[0]}) {
-			/echo Item: ${Me.Inventory[${Math.Calc[${packArray[${i}]}+22]}]} --- ${lootSetting}
-		} else {
-			/echo Item: ${Me.Inventory[${Math.Calc[${packArray[${i}]}+22]}].Item[${Math.Calc[${slotArray[${i}]}]}]} --- ${lootSetting}
-		}
 		/if (${lootSetting.Find[Sell]}) {
+			/if (${slotArray[${i}].Equal[0]}) {
+				/echo Selling: ${Me.Inventory[${Math.Calc[${packArray[${i}]}+22]}]} 
+			} else {
+				/echo Selling: ${Me.Inventory[${Math.Calc[${packArray[${i}]}+22]}].Item[${Math.Calc[${slotArray[${i}]}]}]}
+			}
 			/varset clickAttempts 0
 			:selectItemAgain
 			/if (${slotArray[${i}].Equal[0]}) {
@@ -411,6 +412,7 @@ Sub sellItems
 				/varset clickAttempts ${Math.Calc[${clickAttempts}+1]}
 				/goto :selectItemAgain
 			}
+			/if (${clickAttempts} >= ${maxClickAttempts}) /echo Max clickAttempts reached on :selectItemAgain ${i}
 			/varset clickAttempts 0
 			:pressSellAgain
 			/notify MerchantWnd MW_Sell_Button leftmouseup
@@ -419,6 +421,7 @@ Sub sellItems
 				/varset clickAttempts ${Math.Calc[${clickAttempts}+1]}
 				/goto :pressSellAgain
 			}
+			/if (${clickAttempts} >= ${maxClickAttempts}) /echo Max clickAttempts reached on :pressSellAgain ${i}
 			/delay 1
 			/varset clickAttempts 0
 			:clickQuantityAgain
@@ -428,9 +431,11 @@ Sub sellItems
 				/varset clickAttempts ${Math.Calc[${clickAttempts}+1]}
 				/goto :clickQuantityAgain
 			}
+			/if (${clickAttempts} >= ${maxClickAttempts}) /echo Max clickAttempts reached on :clickQuantityAgain ${i}
 			/delay 3
 		}
 	/next i
+	:sellEmptyInventory
 /if (${Debug} || ${Debug_Sell}) /echo <== sellItems -|
 /return
 
@@ -440,8 +445,9 @@ Sub destroyItems
 	/declare maxClickAttempts int local 5
 	/declare clickAttempts int local 0
 	
-	/call ScanInventory
 	/echo Destroying Items
+	/call ScanInventory
+	/if (${packArray.Size} == 0) /goto destroyEmptyInventory
 	/for i 1 to ${packArray.Size} {
 		/call get_lootSetting pack${packArray[${i}]} ${slotArray[${i}]}
 		/if (${lootSetting.Find[Destroy]}) {
@@ -463,6 +469,7 @@ Sub destroyItems
 				/varset clickAttempts ${Math.Calc[${clickAttempts}+1]}
 				/goto :selectItemAgain
 			}
+			/if (${clickAttempts} >= ${maxClickAttempts}) /echo Max clickAttempts reached on :selectItemAgain
 			/delay 1
 			/varset clickAttempts 0
 			:clickQuantityAgain
@@ -472,11 +479,13 @@ Sub destroyItems
 				/varset clickAttempts ${Math.Calc[${clickAttempts}+1]}
 				/goto :clickQuantityAgain
 			}
+			/if (${clickAttempts} >= ${maxClickAttempts}) /echo Max clickAttempts reached on :clickQuantityAgain
 			/destroy
 			/delay 3
 			/autoinventory
 		}
 	/next i
+	:destroyEmptyInventory
 /if (${Debug} || ${Debug_Sell}) /echo <== destroyItems -|
 /return
 

--- a/Macros/e3 Includes/e3_Sell.inc
+++ b/Macros/e3 Includes/e3_Sell.inc
@@ -396,13 +396,11 @@ Sub sellItems
 	/declare maxClickAttempts int local 10
 	/declare clickAttempts int local 0
 	
-	/echo Selling Items
-	/time
+	/echo Selling Items ${GameTime.Time12}
 	
 	| Scan your inventory into your pack and slot arrays
 	/call ScanInventory
-	/echo ScanInventory Complete
-	/time
+	/echo ScanInventory Complete ${GameTime.Time12}
 	
 	| If your inventory is empty just jump out
 	/if (${packArray.Size} == 0) /goto sellEmptyInventory
@@ -459,8 +457,7 @@ Sub sellItems
 		}
 	/next i
 	:sellEmptyInventory
-	/echo Sell Inventory Complete
-	/time
+	/echo Sell Inventory Complete ${GameTime.Time12}
 /if (${Debug} || ${Debug_Sell}) /echo <== sellItems -|
 /return
 

--- a/Macros/e3 Includes/e3_Sell.inc
+++ b/Macros/e3 Includes/e3_Sell.inc
@@ -394,17 +394,11 @@ Sub sellItems
 	/for i 1 to ${packArray.Size} {
 		/call get_lootSetting pack${packArray[${i}]} ${slotArray[${i}]}
 		/if (${slotArray[${i}].Equal[0]}) {
-			|/echo Item: ${Me.Inventory[${Math.Calc[${packArray[${i}]}+22]}]} --- ${lootSetting}
+			/echo Item: ${Me.Inventory[${Math.Calc[${packArray[${i}]}+22]}]} --- ${lootSetting}
 		} else {
-			|/echo Item: ${Me.Inventory[${Math.Calc[${packArray[${i}]}+22]}].Item[${Math.Calc[${slotArray[${i}]}]}]} --- ${lootSetting}
+			/echo Item: ${Me.Inventory[${Math.Calc[${packArray[${i}]}+22]}].Item[${Math.Calc[${slotArray[${i}]}]}]} --- ${lootSetting}
 		}
 		/if (${lootSetting.Find[Sell]}) {
-			/if (${slotArray[${i}].Equal[0]}) {
-				|/echo Selling Item: ${Me.Inventory[${Math.Calc[${packArray[${i}]}+22]}]}
-			} else {
-				|/echo Selling Item: ${Me.Inventory[${Math.Calc[${packArray[${i}]}+22]}].Item[${Math.Calc[${slotArray[${i}]}]}]}
-			}
-			
 			/varset clickAttempts 0
 			:selectItemAgain
 			/if (${slotArray[${i}].Equal[0]}) {
@@ -450,11 +444,6 @@ Sub destroyItems
 	/echo Destroying Items
 	/for i 1 to ${packArray.Size} {
 		/call get_lootSetting pack${packArray[${i}]} ${slotArray[${i}]}
-		/if (${slotArray[${i}].Equal[0]}) {
-			|/echo Item: ${Me.Inventory[${Math.Calc[${packArray[${i}]}+22]}]} --- ${lootSetting}
-		} else {
-			|/echo Item: ${Me.Inventory[${Math.Calc[${packArray[${i}]}+22]}].Item[${Math.Calc[${slotArray[${i}]}]}]} --- ${lootSetting}
-		}
 		/if (${lootSetting.Find[Destroy]}) {
 			/if (${slotArray[${i}].Equal[0]}) {
 				/echo Destroying Item: ${Me.Inventory[${Math.Calc[${packArray[${i}]}+22]}]}

--- a/Macros/e3 Includes/e3_Sell.inc
+++ b/Macros/e3 Includes/e3_Sell.inc
@@ -361,11 +361,14 @@ sub ScanInventory
 	/declare j int local
 	/declare invSlot int local
 	/declare containerSize int local
+	/declare arraySizeNeeded int local 0
+	/declare arrayCounter int local 1
+	
 	/if (${Defined[packArray]}) { /deletevar packArray }
 	/if (${Defined[slotArray]}) { /deletevar slotArray }
-	/if (${Defined[itemNameArray]}) { /deletevar itemNameArray }
 	
 	/echo Scanning Inventory
+	/echo Calculating array size needed
 	/for i 1 to ${numInventorySlots} {
 		/varcalc invSlot ${Math.Calc[${i}+22]}
 		
@@ -373,19 +376,41 @@ sub ScanInventory
 			/varset containerSize ${Me.Inventory[${invSlot}].Container}
 			/for j 1 to ${containerSize}
 				/if (${Bool[${Me.Inventory[${invSlot}].Item[${j}]}]}) {
-					/call BuildArray packArray ${i}
-					/call BuildArray slotArray ${j}
-					/call BuildArray itemNameArray "${Me.Inventory[${invSlot}].Item[${j}].Name}"
+					/varcalc arraySizeNeeded ${Math.Calc[${arraySizeNeeded}+1]}
 				}
 			/next j
 		} else {
 			/if (${Bool[${Me.Inventory[${invSlot}]}]}) {
-				/call BuildArray packArray ${i}
-				/call BuildArray slotArray 0
-				/call BuildArray itemNameArray "${Me.Inventory[${invSlot}].Name}"
+				/varcalc arraySizeNeeded ${Math.Calc[${arraySizeNeeded}+1]}
 			}
 		}
 	/next i
+	
+	/declare packArray[${arraySizeNeeded}]
+	/declare slotArray[${arraySizeNeeded}]
+
+	/echo Inserting items into Arrays
+	/for i 1 to ${numInventorySlots} {
+		/varcalc invSlot ${Math.Calc[${i}+22]}
+		
+		/if (${Bool[${Me.Inventory[${invSlot}].Container}]}) {
+			/varset containerSize ${Me.Inventory[${invSlot}].Container}
+			/for j 1 to ${containerSize}
+				/if (${Bool[${Me.Inventory[${invSlot}].Item[${j}]}]}) {
+					/varset packArray[${arrayCounter}] ${i}
+					/varset slotArray[${arrayCounter}] ${j}
+					/varcalc arrayCounter ${Math.Calc[${arrayCounter}+1]}
+				}
+			/next j
+		} else {
+			/if (${Bool[${Me.Inventory[${invSlot}]}]}) {
+				/varset packArray[${arrayCounter}] ${i}
+				/varset slotArray[${arrayCounter}] 0
+				/varcalc arrayCounter ${Math.Calc[${arrayCounter}+1]}
+			}
+		}
+	/next i
+	/echo Scan Inventory complete
 /if (${Debug} || ${Debug_Sell}) /echo <== sellItems -|
 /Return
 

--- a/Macros/e3 Includes/e3_Sell.inc
+++ b/Macros/e3 Includes/e3_Sell.inc
@@ -386,8 +386,8 @@ sub ScanInventory
 		}
 	/next i
 	
-	/declare packArray[${arraySizeNeeded}]
-	/declare slotArray[${arraySizeNeeded}]
+	/declare packArray[${arraySizeNeeded}] string outer
+	/declare slotArray[${arraySizeNeeded}] string outer
 
 	/echo Inserting items into Arrays
 	/for i 1 to ${numInventorySlots} {

--- a/Macros/e3 Includes/e3_Sell.inc
+++ b/Macros/e3 Includes/e3_Sell.inc
@@ -397,9 +397,12 @@ Sub sellItems
 	/declare clickAttempts int local 0
 	
 	/echo Selling Items
+	/time
 	
 	| Scan your inventory into your pack and slot arrays
 	/call ScanInventory
+	/echo ScanInventory Complete
+	/time
 	
 	| If your inventory is empty just jump out
 	/if (${packArray.Size} == 0) /goto sellEmptyInventory
@@ -456,6 +459,8 @@ Sub sellItems
 		}
 	/next i
 	:sellEmptyInventory
+	/echo Sell Inventory Complete
+	/time
 /if (${Debug} || ${Debug_Sell}) /echo <== sellItems -|
 /return
 


### PR DESCRIPTION
This contains an updated Autosell routine that tends to be a little more reliable than the existing version.  The old Autosell was exiting after some items sold and many people were complaining that it would take 4 or 5 times to properly sell all the items in their bags.

There was a change made to the e3_Loot.inc as well to fix/improve looking through the inventory.  The old macro used the Corpse which was giving null values, so this was changed to the Me.Inventory locations which ended up being more reliable.

Some performance improvements were made to like simple /shift commands before the /notify commands in an attempt to keep the quantity window from popping up.   Quite a few users have helped test this and it feels like it's a better version of autosell at this point.