### PR TITLE
Update e3_Basics.inc

### DIFF
--- a/Macros/e3 Includes/e3_Basics.inc
+++ b/Macros/e3 Includes/e3_Basics.inc
@@ -278,7 +278,7 @@ SUB EVENT_clickIt(line, ChatSender, eventParams)
     /for i 1 to ${doorList.Size}
       /if (${debug_clickit}) /echo ${i} ${doorList[${i}]}
       /squelch /doortarget id ${doorList[${i}].Arg[1,,]}
-      /if ((${closestDoorDist}==0 || ${DoorTarget.Distance} < ${closestDoorDist}) && ${DoorTarget.Distance} < 400) {
+      /if ((${closestDoorDist}==0 || ${DoorTarget.Distance} < ${closestDoorDist}) && ${DoorTarget.Distance} < 400 && ${DoorTarget.Distance}) {
         /varset closestDoorDist ${DoorTarget.Distance}
         /varset closestDoorID ${doorList[${i}].Arg[1,,]}
       }


### PR DESCRIPTION
NULL value is evaluating to less than 0 and the if condition that checks for closest distance thinks NULL is less than 0, so it assigns that as the door ID.

From POK, /clickit on the Nexus book was failing for my group because a DoorID in the list didn't exist.

TLDR, makes sure that ${DoorTarget.Distance} is NOT NULL before assigning the Door ID.