### PR TITLE
Group/improvement

### DIFF
--- a/Macros/e3 Includes/e3_Basics.inc
+++ b/Macros/e3 Includes/e3_Basics.inc
@@ -1391,9 +1391,6 @@ SUB EVENT_groupUp(line, ChatSender, createGroup)
 /if (${Debug}) /echo |- EVENT_groupUp ==>
   /if (!${checkEventArgs[${ChatSender},${line},U,${createGroup}]}) /return
   /if (${c_eventArgChatSender.Equal[${Me.Name}]}) {
-    /squelch /bca //raiddisband
-    /squelch /bca //disband
-    /delay 5
     /if (${Raid.Members}) /raiddisband
   }
   /delay 5
@@ -1413,12 +1410,27 @@ SUB EVENT_groupUp(line, ChatSender, createGroup)
       /echo Recalling [${groupName}]...
       /echo [${Time}] Delaying up to 1.5 second(s) in EVENT_groupUp
       /delay 15
+      | Disband members only if they are part of this group
+      /for e 1 to 5
+      /varset groupMembers[${e}] ${${IniMode}[${Group_Ini},${${IniMode}[${Group_Ini}].Arg[${i},|]},GroupMember#${e}]}
+      /if (${${IniMode}[${Group_Ini},${${IniMode}[${Group_Ini}].Arg[${i},|]},GroupMember#${e}].NotEqual[PLACEHOLDER]}) {
+        /varcalc groupSize ${groupSize}+1
+        | -Alert PC of incoming group invite.
+	/squelch /bct ${groupMembers[${e}]} //raiddisband
+	/squelch /bct ${groupMembers[${e}]} //disband
+      }
+      /next e
+      /delay 5
+	  
       | Invite group members while ignoring placeholders, and set
       /for e 1 to 5
       /varset groupMembers[${e}] ${${IniMode}[${Group_Ini},${${IniMode}[${Group_Ini}].Arg[${i},|]},GroupMember#${e}]}
       /if (${${IniMode}[${Group_Ini},${${IniMode}[${Group_Ini}].Arg[${i},|]},GroupMember#${e}].NotEqual[PLACEHOLDER]}) {
         /varcalc groupSize ${groupSize}+1
         | -Alert PC of incoming group invite.
+	/squelch /bct ${groupMembers[${e}]} //raiddisband
+	/squelch /bct ${groupMembers[${e}]} //disband
+	/delay 5
         /invite ${groupMembers[${e}]}
       }
       /next e

--- a/Macros/e3 Includes/e3_Basics.inc
+++ b/Macros/e3 Includes/e3_Basics.inc
@@ -1428,9 +1428,6 @@ SUB EVENT_groupUp(line, ChatSender, createGroup)
       /if (${${IniMode}[${Group_Ini},${${IniMode}[${Group_Ini}].Arg[${i},|]},GroupMember#${e}].NotEqual[PLACEHOLDER]}) {
         /varcalc groupSize ${groupSize}+1
         | -Alert PC of incoming group invite.
-	/squelch /bct ${groupMembers[${e}]} //raiddisband
-	/squelch /bct ${groupMembers[${e}]} //disband
-	/delay 5
         /invite ${groupMembers[${e}]}
       }
       /next e


### PR DESCRIPTION
When you recall a group, it currently sends out a /bca command to disband everyone **even if they aren't part of the group you are creating.**  With this logic you can't have more than a single group recalled with this command.    This update only sends a disband command to a person if they are part of the group you are trying to create.  This takes a little more time but allows you to recall multiple groups connected to the same server.

Tests for old logic to show what I mean
  - Log on 12 players with 2 distinct groups player 1-6 in group 1 and player 7-12 in group 2(create these groups ahead of time)
  - Recall group 1 and then try to recall group 2.  Group 1 will get disbanded

Tests for new logic
  - Log on 12 players with 2 distinct groups player 1-6 in group 1 and player 7-12 in group 2
  - invite p1, p2, p3, p7, p8, p9 into g1 and then recall g2 .  G1 should still contain p1, p2, p3 when done and g2 should have the full group
  - log on all 12, with no one in groups.  Recall g1 and g2.  Both groups should be created when done