### PR TITLE
Feature/clear x target toggle

### DIFF
--- a/Macros/e3 Includes/e3_ClearXTargets.inc
+++ b/Macros/e3 Includes/e3_ClearXTargets.inc
@@ -98,16 +98,23 @@ SUB event_clearXTargets(line, ChatSender, args)
     /varset KeepAggroOn FALSE
   }
 
-  | toggle ClearXTargetsOn on/off 
-  /if (!${ClearXTargetsOn}) {
-    /varset ClearXTargetsOn TRUE
-    | Disable follow to stop melee/ranged toons bouncing
-    /stop
-  	/echo ClearXTargets: Enabled ${ClearXTargetsOn}
-  } else {
-    /varset ClearXTargetsOn FALSE
-	  /echo ClearXTargets: Disabled
-  }
+  /if (${Bool[${args.Find[ForceOn]}]}) {
+	/varset ClearXTargetsOn TRUE
+	/stop
+	/echo ClearXTargets: Enabled ${ClearXTargetsOn}
+} else /if (${Bool[${args.Find[ForceOff]}]}) {
+	/varset ClearXTargetsOn FALSE
+	/echo ClearXTargets: Disabled
+} else /if (!${ClearXTargetsOn}) {
+	/varset ClearXTargetsOn TRUE
+	| Disable follow to stop melee/ranged toons bouncing
+	/stop
+	/echo ClearXTargets: Enabled ${ClearXTargetsOn}
+ } else {
+	/varset ClearXTargetsOn FALSE
+	/echo ClearXTargets: Disabled
+ }
+
 /RETURN
 
 | Selects the next target and attacks

--- a/Macros/e3 Includes/e3_ClearXTargets.inc
+++ b/Macros/e3 Includes/e3_ClearXTargets.inc
@@ -99,22 +99,21 @@ SUB event_clearXTargets(line, ChatSender, args)
   }
 
   /if (${Bool[${args.Find[ForceOn]}]}) {
-	/varset ClearXTargetsOn TRUE
-	/stop
-	/echo ClearXTargets: Enabled ${ClearXTargetsOn}
-} else /if (${Bool[${args.Find[ForceOff]}]}) {
-	/varset ClearXTargetsOn FALSE
-	/echo ClearXTargets: Disabled
-} else /if (!${ClearXTargetsOn}) {
-	/varset ClearXTargetsOn TRUE
-	| Disable follow to stop melee/ranged toons bouncing
-	/stop
-	/echo ClearXTargets: Enabled ${ClearXTargetsOn}
- } else {
-	/varset ClearXTargetsOn FALSE
-	/echo ClearXTargets: Disabled
- }
-
+    /varset ClearXTargetsOn TRUE
+    /stop
+    /echo ClearXTargets: Enabled ${ClearXTargetsOn}
+  } else /if (${Bool[${args.Find[ForceOff]}]}) {
+    /varset ClearXTargetsOn FALSE
+    /echo ClearXTargets: Disabled
+  } else /if (!${ClearXTargetsOn}) {
+    /varset ClearXTargetsOn TRUE
+    | Disable follow to stop melee/ranged toons bouncing
+    /stop
+    /echo ClearXTargets: Enabled ${ClearXTargetsOn}
+  } else {
+    /varset ClearXTargetsOn FALSE
+    /echo ClearXTargets: Disabled
+  }
 /RETURN
 
 | Selects the next target and attacks


### PR DESCRIPTION
ClearXTargets currently works as a toggle when you call it.   When it's assigned to a social button, it's easy to accidentally click the social more than once which will stop combat inadvertently.   I've added in an option for an additional optional argument that will allow you to force it on or off.   No argument will retain the current functionality and still toggle it on/off as it currently exists.

/clearxtargets [ForceOn|ForceOff] are availabe with this change.

The keepAggro arguments should still work as well in conjunction with the ForceOn and ForceOff arguments.

I've been testing this code for month as part of some scripts I use, so it feels pretty solid to me.